### PR TITLE
feat(ci): adopt release-publish workflow and add drafter dispatch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,10 +6,11 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - develop
+  workflow_dispatch:
 
 jobs:
   update_release_draft:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-drafter.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,24 @@
+---
+name: Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (must match an open release-drafter draft)."
+        required: true
+        type: string
+      dry_run:
+        description: "Validate without flipping draft=false."
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18
+    with:
+      tag: ${{ inputs.tag }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ mkdocs-include-markdown-plugin==7.2.0
 mkdocs-material==9.7.0
 mkdocs==1.6.1
 pre-commit==4.5.0
-pymdown-extensions==10.17.1
+pymdown-extensions==10.21.3


### PR DESCRIPTION
## Summary

Close the gap that blocked the `nolte-shared:release-publish-trigger` skill: this repository lacked `release-publish.yml`, and `release-drafter.yml` had no manual dispatch trigger so the post-automerge cascade gap couldn't be recovered. After this PR, both release-layer skills (`release-notes-curate` and `release-publish-trigger`) operate against this repo unchanged. Also bumps `pymdown-extensions` so the published docs render fenced code blocks correctly.

## Changes

- Add `.github/workflows/release-publish.yml` consuming `nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18`, exposing `workflow_dispatch` with the spec-mandated `tag` (required) and `dry_run` (optional) inputs.
- Add `workflow_dispatch` trigger to `.github/workflows/release-drafter.yml` so the spec's manual recovery path (`gh workflow run release-drafter.yml --ref develop`) works when an automerge-bot push fails to cascade.
- Bump the `release-drafter.yml` reusable pin from `v1.1.12` to `v1.1.18` so both release-layer workflows pin the same `gh-plumbing` release.
- Bump `pymdown-extensions` in `requirements-dev.txt` from `10.17.1` to `10.21.3`. The `10.17.x` `superfences` parser parses ```lang ... ``` blocks as inline-code spans inside `<p>` tags instead of fenced `<pre><code>` blocks; `Archive layout` and `Usage` on the docs site rendered as inline text. `>= 10.21.3` restores correct fenced-block recognition.

## Linked issues

None — initiated by an audit of `release-notes-curate` and `release-publish-trigger` skill preconditions against this repo, plus a docs-rendering issue surfaced while verifying the build.

## Testing

- `task lint` — pre-commit (check-yaml, end-of-file-fixer, trailing-whitespace) passes locally on every touched file.
- `task docs` — `mkdocs build --strict` succeeds; rendered `site/index.html` now contains real `<div class="highlight"><pre><code>` fenced code blocks (4 occurrences) with syntax highlighting, replacing the previous broken inline-code rendering.
- `task test` — `vale .` runs clean (0 errors, 0 warnings, 0 suggestions in 12 files).
- Upstream reusable target verified to exist: `nolte/gh-plumbing/.github/workflows/reusable-release-publish.yml@v1.1.18`.
- End-to-end smoke verification of the publish workflow deferred to first dispatch: once a `release-drafter` draft exists on `develop`, the operator runs `gh workflow run release-publish.yml --ref develop -f tag=<tag> -f dry_run=true` and verifies every validation gate passes before flipping to a live publish.

## Risk / rollout notes

- **Blast radius**: CI configuration plus one docs-dependency pin; no application code touched. Rollback = revert the two commits.
- **No version-bearing files**: the upstream reusable's project-type detection returns `source: none` for this repo (no `plugin.json`, no `pyproject.toml`, no `package.json`, no HACS manifest). The version-bearing-file alignment step is skipped (`count == 0`), which is correct for a ZIP-asset repo where the git tag is the single source of truth.
- **Reusable bump `v1.1.12` → `v1.1.18`**: six patch releases, no breaking changes documented for `reusable-release-drafter.yml`. The bump is scoped to `release-drafter.yml` only; the other `gh-plumbing@v1.1.12` pins (`automerge.yaml`, `release-cd-*`, `build-static-tests.yaml`, `spelling.yaml`) stay untouched on purpose.
- **`pymdown-extensions` bump `10.17.1` → `10.21.3`**: four-patch-range jump, no breaking-change notice in the upstream changelog for the touched extensions (`superfences`, `inlinehilite`, `highlight`). Only consumer is `mkdocs build`; verified locally.
- **Out of scope (tracked separately)**:
  - `automerge.yaml` produces merge-commits instead of squash (workflow-health finding from PR #7's merge).
  - `release-drafter.yml` doesn't cascade after automerge-bot commits (`GITHUB_TOKEN` cascading default — this PR's `workflow_dispatch` adds the manual recovery path, but doesn't fix the cascade itself).
  - Bumping the remaining `gh-plumbing@v1.1.12` pins.
