### PR TITLE
feat(ci): add workflow_dispatch to release-cd-* workflows

### DIFF
--- a/.github/workflows/release-cd-archive.yml
+++ b/.github/workflows/release-cd-archive.yml
@@ -1,6 +1,12 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to attach the ZIP to (manual recovery only). Required for workflow_dispatch; ignored on `release: [published]`."
+        required: true
+        type: string
 
 jobs:
   archive:
@@ -22,6 +28,7 @@ jobs:
     - name: Upload Release
       uses: ncipollo/release-action@v1.20.0
       with:
+          tag: ${{ inputs.tag || github.event.release.tag_name }}
           artifacts: "nolte-styles.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true

--- a/.github/workflows/release-cd-deliver-docs.yml
+++ b/.github/workflows/release-cd-deliver-docs.yml
@@ -1,10 +1,11 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish_docs:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-mkdocs.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     permissions:

--- a/.github/workflows/release-cd-refresh-master.yml
+++ b/.github/workflows/release-cd-refresh-master.yml
@@ -1,10 +1,11 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   refresh_presentation_branch:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-release-cd-refresh-master.yml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to all three `release-cd-*.yml` workflows so the post-`release-publish.yml` cascade can be recovered manually when GitHub's `GITHUB_TOKEN`-cascade default suppresses it. Observed on v0.1.9: the publish workflow finished green at 16:45:38Z, but archive, deliver-docs, and refresh-master all skipped; recovery required a manual `gh release edit --draft=true && --draft=false` round-trip from the operator's user token, which is ugly in the audit trail.

## Changes

- `release-cd-deliver-docs.yml`: add `workflow_dispatch:` (no inputs — the reusable `mkdocs` build uses the dispatched ref, which on `develop` matches the release-tag commit). Bump reusable pin `v1.1.12 → v1.1.18` for portfolio consistency with `release-drafter.yml` and `release-publish.yml`.
- `release-cd-archive.yml`: add `workflow_dispatch:` with a **required** `tag` input. `ncipollo/release-action` without an explicit tag falls back to `GITHUB_REF`, which on `--ref develop` would create a release tagged `refs/heads/develop`. The new input plus `${{ inputs.tag || github.event.release.tag_name }}` selector handles both trigger surfaces (no Reusable in this workflow, so no pin to bump).
- `release-cd-refresh-master.yml`: add `workflow_dispatch:` (no inputs — the reusable performs a deterministic `develop → main` fast-forward). Bump reusable pin `v1.1.12 → v1.1.18`.

## Linked issues

None — surfaced while verifying v0.1.9 publish. No `spec/` files touched.

## Testing

- `task lint` — pre-commit (check-yaml, end-of-file-fixer, trailing-whitespace) passes locally.
- YAML triggers smoke-checked against the GitHub Actions schema (no `strict`-build for workflows here, but `check-yaml` pre-commit catches structural breakage).
- End-to-end smoke deferred to the next release cycle: once this lands on `develop`, the three workflows are available as `gh workflow run release-cd-deliver-docs.yml --ref develop`, `gh workflow run release-cd-archive.yml --ref develop -f tag=v0.1.X`, and `gh workflow run release-cd-refresh-master.yml --ref develop` for manual cascade recovery.

## Risk / rollout notes

- **Blast radius**: CI configuration only; no application code touched. Rollback = revert this commit.
- **Reusable bumps `v1.1.12 → v1.1.18`** affect two of three workflows (`reusable-mkdocs.yaml` and `reusable-release-cd-refresh-master.yml`); six patch releases each, no breaking changes documented in the upstream changelog. After this PR lands, `automerge.yaml` is the only remaining `gh-plumbing@v1.1.12` pin in the repo.
- **`release-cd-archive.yml` tag-input is required** to avoid the `GITHUB_REF`-fallback failure mode; operators dispatching it manually must pass `-f tag=<existing-release-tag>`. The other two workflows take no inputs (deterministic by ref).
- **Out of scope (tracked separately)**:
  - Root-cause fix of the `GITHUB_TOKEN` cascade default: replace with a PAT or App token in `gh-plumbing` commons-settings so `release-publish.yml`'s `release:published` event cascades automatically. Cross-repo change, not local to `vale-style`.
  - `actions/checkout@master` (loose branch ref) in `release-cd-archive.yml` should be pinned to a tag or SHA — separate hardening PR.
  - `automerge.yaml` reusable pin (still at `v1.1.12`) and its squash-vs-merge strategy bug (workflow-health finding from PR #7).