### PR TITLE
feat(project): adopt project-planning suite per nolte-shared specs

### DIFF
--- a/AUDIENCES.md
+++ b/AUDIENCES.md
@@ -1,0 +1,87 @@
+# Audiences — vale-style
+
+<!--
+Produced via the `audience-identify` skill, following
+spec/project/audience-identification/ in claude-shared.
+Do not add audiences without first declaring the bounded context below.
+-->
+
+## Bounded context
+
+- **What this is:** A versioned Vale style package, distributed as the GitHub release artifact `nolte-styles.zip`. Contents: curated Vale vocabularies (`technical`, `esphome`) under `src/styles/config/vocabularies/<group>/accept.txt`, a package-internal `.vale.ini`, and a placeholder `src/styles/nolte-styles/` for future Vale rule YAML. Consuming repositories integrate the package via a `Packages` entry plus `StylesPath` in their own Vale configuration.
+- **Boundaries:**
+  - Source of truth for the shipped vocabularies and (future) rule sets
+  - Curation specs under `spec/<slug>/<lang>.md` that codify accept / reject rules
+  - Dogfooding via the root `/.vale.ini` (lints this repository's own markdown against the shipped vocabularies)
+  - MkDocs site (`docs/`) as consumer-facing documentation
+  - CI and release plumbing via reusable workflows from `nolte/gh-plumbing`
+- **Explicitly out of scope:**
+  - How consuming repositories assemble their own `.vale.ini` (consumer responsibility)
+  - The Vale engine itself (external toolchain dependency)
+  - Non-Vale linters (for example prose linters without a Vale backend)
+  - Content-level judgments on whether a single term is "correct" — decided through curation specs, not ad hoc
+  - Distribution outside GitHub releases (no npm, PyPI, or Homebrew publication path)
+
+## Audiences
+
+Each entry: label, relationship category, interaction surface, expectation,
+open questions, `confirmed` or `assumed`, criticality (primary / secondary /
+peripheral). A whole category is marked `none — <reason>` when it does not apply.
+
+### Direct consumers
+
+- **nolte/* consumer repositories** — _category_: direct-consumer · _surface_: `.vale.ini` `Packages` entry, GitHub release URL · _expects_: stable, semver-versioned ZIP URL; runnable vocabularies; backwards-compatible vocabulary names (`technical`, `esphome`) · _status_: `assumed` · _criticality_: primary
+  - Open questions: which `nolte/*` repos actually consume this package today? Is the list discoverable via a search across `nolte/*` for `Packages = nolte-styles` style strings?
+- **CI pipelines in consumer repos** — _category_: direct-consumer · _surface_: `vale-action` or `vale .` in GitHub Actions workflows · _expects_: reproducible lint runs, no flaky vocabulary drift, no breaking changes without a major version bump · _status_: `assumed` · _criticality_: primary
+  - Open questions: do consumers pin to a specific release tag, or do they float on `latest`? The answer changes the blast radius of every release.
+- **Local developers in consumer repos** — _category_: direct-consumer · _surface_: `vale .` CLI locally · _expects_: identical behaviour locally and in CI; documented accept / exception syntax · _status_: `assumed` · _criticality_: secondary
+  - Open questions: are developers expected to install Vale themselves, or via a project-level task / devcontainer?
+- **External consumers (public, non-`nolte`)** — _category_: direct-consumer · _surface_: GitHub release asset on the public repo · _expects_: discoverability via GitHub search / README, licence clarity · _status_: `assumed` · _criticality_: peripheral
+  - Open questions: is external adoption a goal, or a tolerated side-effect of the repo being public?
+
+### Operators
+
+- **nolte (repository maintainer)** — _category_: operator · _surface_: GitHub Releases UI, `Taskfile.yml`, `.github/workflows/release-*` · _expects_: runnable `task build` / `task test` / `task docs`; reproducible release cuts via release-drafter → `release-cd-archive.yml`; predictable semver bumps · _status_: `assumed` · _criticality_: primary
+  - Open questions: none beyond ordinary release hygiene.
+- **GitHub Actions runners / platform** — _category_: operator · _surface_: workflow YAML, reusable workflows pinned to `nolte/gh-plumbing@v1.1.12` · _expects_: stable pinned versions, deterministic builds, no unpinned actions · _status_: `assumed` · _criticality_: secondary
+  - Open questions: none.
+- **Renovate / Mend bot** — _category_: operator · _surface_: `renovate.json5`, Probot Settings · _expects_: readable dependency definitions, PRs against `develop`, grouped `group:all` updates · _status_: `assumed` · _criticality_: peripheral
+  - Open questions: is the Mend dashboard reachable and showing activity for this repo? (verifiable via Renovate-app installation check)
+
+### Contributors / maintainers
+
+- **nolte (primary maintainer)** — _category_: contributor · _surface_: local `git`, PR flow on `develop`, Conventional Commits, pre-commit, Taskfile · _expects_: working hooks, fast local lint (`task test`), traceable develop → main release path · _status_: `assumed` · _criticality_: primary
+  - Open questions: none.
+- **Claude Code agents / skills** (`prose-vale-curator`, `vocab-drift-audit` from `claude-shared`) — _category_: contributor · _surface_: skill invocations against `src/styles/.../accept.txt`, `.claude/settings.json` permission allowlist · _expects_: writable vocabulary files, PR flow against `develop`, curation specs under `spec/` to ground decisions · _status_: `assumed` · _criticality_: primary
+  - Open questions: which skills should be allow-listed without per-call prompts, and which require a confirm step (per `permission-allowlist-maintain`)?
+- **External contributors** — _category_: contributor · _surface_: GitHub PRs, `CONTRIBUTING.md`, issue templates · _expects_: documented accept / reject rules (specs under `spec/`), traceable CI checks (Vale, Trivy, chain-bench, MkDocs `--strict`) · _status_: `assumed` · _criticality_: secondary
+  - Open questions: is external contribution actively solicited, or only opportunistically accepted?
+
+### Governing parties
+
+- **nolte (repo owner)** — _category_: governing · _surface_: branch protection rules, `.github/settings.yml` via Probot Settings, spec approval · _expects_: veto authority on vocabulary and style changes; final say on semver-major cuts · _status_: `assumed` · _criticality_: primary
+  - Open questions: none.
+- **nolte portfolio consensus** (specs under `claude-shared/spec/`) — _category_: governing · _surface_: pull-request-workflow, branching-model, release-automation, project-structure specs · _expects_: repo stays conformant; deviations propagate via spec update, not silently · _status_: `assumed` · _criticality_: primary
+  - Open questions: does this repo need its own per-spec opt-out tracking, or does conformance suffice?
+
+### Indirect audiences
+
+- **Readers of markdown content in consumer repos** — _category_: indirect · _surface_: rendered README / docs / ADRs in `nolte/*` repos, processed through Vale · _expects_: consistent spelling and correct technical terms (`Probot`, `ESPHome`, `LEDs`); no linguistic inconsistencies across repos · _status_: `assumed` · _criticality_: secondary
+  - Open questions: how is "consistency across repos" measured today — anecdotally, or via a portfolio-wide audit?
+- **FOSS community as reference consumers** — _category_: indirect · _surface_: public GitHub repo, MkDocs site · _expects_: the repo serves as a traceable template for their own Vale style packages; clear licence footprint · _status_: `assumed` · _criticality_: peripheral
+  - Open questions: is reference value an explicit goal, or only a side benefit?
+
+## Open questions (cross-cutting)
+
+- Should consumer-repo discovery (which `nolte/*` repos depend on this package, at which version) be tracked here, or in a separate `consumers.md` / portfolio register?
+- Is there a minimum threshold below which a new vocabulary entry should be added directly versus via spec update?
+- Does the audience list need explicit re-validation when `claude-shared` introduces a new spec that this repo must conform to (for example a new portfolio-wide gate)?
+
+## Revisit triggers
+
+- A new vocabulary group is added beyond `technical` and `esphome`
+- `src/styles/nolte-styles/` graduates from placeholder to shipping rule YAML
+- The release pipeline moves off `nolte/gh-plumbing` reusable workflows
+- A consuming repository is identified outside `nolte/*` and adopted as an explicit audience
+- A regulated data class is introduced (currently none — pure FOSS vocabulary content)
+- A new Claude Code skill or agent claims this repo as a write target

--- a/project/features/vocabulary-curation-spec.md
+++ b/project/features/vocabulary-curation-spec.md
@@ -1,0 +1,96 @@
+---
+id: F-1
+title: Vocabulary curation spec open questions closed
+status: ready
+roadmap_item: R-1
+sprint: 1
+created: 2026-05-18
+ended: null
+verifies_sprint_value: acceptance-5
+consistency_check:
+  performed_at: 2026-05-18
+  agent_version: feature-consistency-reviewer@b4ae9e0
+  findings:
+    - kind: clean
+      target: n/a
+      resolution: proceed
+---
+
+## Description
+
+The `spec/vocabulary-and-style-curation/{en,de}.md` specification ships as
+`Status: draft` and carries four Open Questions that block downstream
+consumers — curator agents (`prose-vale-curator`, `vocab-drift-audit` from
+`claude-shared`) and reviewers — from citing the spec authoritatively. This
+feature closes those questions: each is either decided and folded into the
+`Requirements` (or `Acceptance Criteria`) section, or formally deferred with
+a written rationale that names the awaited event. After the feature ships,
+every term and rule decision can quote a settled rule instead of a draft
+one.
+
+## Acceptance criteria
+
+- [ ] **acceptance-1** Open Question 1 (alphabetical sorting as MUST?) is
+      decided and incorporated into the Requirements section of
+      `spec/vocabulary-and-style-curation/en.md`, or removed from the
+      `## Open Questions` list with a rationale.
+- [ ] **acceptance-2** Open Question 2 (rule authoring scope — own spec
+      vs. extension of this one) is decided.
+- [ ] **acceptance-3** Open Question 3 (removal policy) is decided.
+- [ ] **acceptance-4** Open Question 4 (vocabulary group vetting procedure)
+      is decided.
+- [ ] **acceptance-5** Every remaining bullet in the `## Open Questions`
+      section of `spec/vocabulary-and-style-curation/en.md` either
+      disappears or carries a `deferred until <event>` annotation.
+- [ ] **acceptance-6** `spec/vocabulary-and-style-curation/de.md` mirrors
+      the EN structure after all changes (same headings, same requirement
+      bullets).
+
+## Test hooks
+
+- **acceptance-1** — manual: review Requirements diff for sorting-policy
+  decision — pending
+- **acceptance-2** — manual: review for rule-authoring-scope decision —
+  pending
+- **acceptance-3** — manual: review for removal-policy decision — pending
+- **acceptance-4** — manual: review for vetting-procedure decision —
+  pending
+- **acceptance-5** — `awk '/^## Open Questions/{f=1;next} /^## /{f=0} f && /^- / && !/deferred until/' spec/vocabulary-and-style-curation/en.md | wc -l`
+  returns `0` — pending
+- **acceptance-6** — manual: structural diff EN ↔ DE (heading parity,
+  bullet parity) — pending
+
+## Consistency notes
+
+The `feature-consistency-reviewer` agent re-run at SHA `b4ae9e0` after the
+draft was redesigned. The earlier `duplication` finding (against
+`spec/vocabulary-and-style-curation/en.md`) and the earlier `drift` finding
+(against the bracket-class MUST in the same spec, line 36) were both
+dissolved by construction:
+
+- the feature now consumes the existing spec by closing its Open Questions
+  in place rather than re-authoring rules in parallel, and
+- the `[Pp]robot` example was removed entirely, so no acceptance criterion
+  contradicts the bracket-class MUST.
+
+The clean re-review records `proceed` as the only resolution available for
+a `kind: clean` finding per the canonical feature spec's resolution
+vocabulary. No sibling features exist to merge into, supersede, or split
+out toward.
+
+## Risks
+
+- **Bikeshedding on Open Question 1 (alphabetical sorting).** Diff-review
+  ergonomics is a legitimate concern but turning it into a MUST might
+  force noisy re-ordering PRs. Mitigation: prefer a SHOULD or a tooling
+  hook over a MUST unless the operator explicitly votes otherwise.
+- **Premature decision on Open Question 4 (group vetting).** No external
+  consumer is identified today, so the "at least one external consumer
+  identified first" branch is hard to validate. Mitigation: accept the
+  internal-consumer-only path as the working default and defer the
+  external-consumer branch until a real consumer appears.
+- **DE/EN drift during the same feature.** Closing four Open Questions in
+  EN while keeping DE structurally in sync is a real chore; a partial
+  merge that updates EN but forgets DE breaks `acceptance-6`. Mitigation:
+  ship EN and DE changes in the same commit per the existing spec-
+  translation conventions.

--- a/project/goals.md
+++ b/project/goals.md
@@ -1,0 +1,24 @@
+# Vision
+
+`vale-style` supplies the nolte portfolio with curated Vale vocabularies and
+(later) style rules, so that markdown content across every `nolte/*`
+repository is linted consistently and technical terms like `Probot`,
+`ESPHome`, or `LEDs` are decided in one place rather than reinvented per
+repository.
+
+## Outcomes
+
+- **O-1** — Consumer repository maintainers integrate the package via a single
+  `.vale.ini` `Packages` entry and get a working lint setup without
+  duplicating vocabularies. _(audience: nolte/\* consumer repositories)_
+- **O-2** — CI pipelines in consumer repos stay deterministic across
+  releases; vocabulary changes ship through semver-versioned release tags
+  rather than silent drift. _(audience: CI pipelines in consumer repos)_
+- **O-3** — Local developers see identical lint behaviour locally and in CI,
+  so corrections happen before push. _(audience: local developers in consumer repos)_
+- **O-4** — Readers of markdown across the nolte portfolio see consistent
+  spelling and correct technical terms regardless of which repo they land
+  in. _(audience: readers of markdown content in consumer repos)_
+- **O-5** — Maintainers (human or skill-driven) add a new vocabulary entry
+  through a spec-grounded PR without learning the package layout from
+  scratch. _(audience: nolte primary maintainer, Claude Code agents)_

--- a/project/mission.md
+++ b/project/mission.md
@@ -1,0 +1,98 @@
+---
+mission_statement: vale-style ships a single curated Vale style package that consuming nolte/* repositories integrate via one .vale.ini entry to lint markdown consistently across the portfolio.
+relevant_outcomes: [O-5]
+audiences:
+  - "nolte/* consumer repositories"
+  - "Claude Code agents / skills"
+  - "nolte (primary maintainer)"
+verifies_via: F-1:acceptance-5
+time_bound:
+  kind: mvp_completion
+mvp_status: defining
+created: 2026-05-18
+revised_at: null
+---
+
+## Statement
+
+vale-style ships a single curated Vale style package that consuming
+`nolte/*` repositories integrate via one `.vale.ini` entry to lint
+markdown consistently across the portfolio.
+
+SMART decomposition:
+
+- **Specific** — `mission_statement` names the deliverable (a curated Vale
+  style package distributed as a single ZIP) and the "for whom" (`nolte/*`
+  consumer repositories plus the Claude Code curator agents and the
+  primary maintainer who keep the package authoritative).
+- **Measurable** — `verifies_via: F-1:acceptance-5` anchors achievement on
+  one concrete acceptance criterion (every Open Question in
+  `spec/vocabulary-and-style-curation/en.md` resolved or formally
+  deferred). When that criterion is checked, the mission is measurably
+  achieved.
+- **Achievable** — the MVP scope is exactly one roadmap item (R-1),
+  targeted at sprint 1 with `detail: fine`. One item, one sprint — well
+  below the two-to-five-sprints SMART bound.
+- **Relevant** — `relevant_outcomes: [O-5]` ties the mission to the
+  outcome it directly delivers: curator agents and maintainers cite
+  written rules instead of guessing. Outcomes O-1 through O-4 benefit
+  indirectly once the curation rules are settled but aren't claimed here.
+- **Time-bound** — `time_bound: { kind: mvp_completion }` binds the
+  mission to the moment `mvp_status` reaches `achieved`. No calendar date,
+  per the spec's prohibition on calendar deadlines for hobby-scale
+  projects.
+
+## Audiences
+
+### nolte/* consumer repositories
+
+These repositories integrate `nolte-styles.zip` via a `.vale.ini`
+`Packages` entry. The MVP delivers them a citable curation reference (the
+settled `vocabulary-and-style-curation` spec) so they can quote a written
+rule when a vocabulary change lands rather than reading the repo's git
+history. Concretely: every new term added to an `accept.txt` arrives with
+a PR description that names which spec rule justifies it, which is the
+auditability consumer repos need to know upstream additions won't silently
+break their lint output.
+
+### Claude Code agents / skills
+
+The curator agents (`prose-vale-curator`, `vocab-drift-audit` from
+`claude-shared`) need a stable, citable spec to ground their automated
+curation decisions. The MVP delivers them exactly that: every Open
+Question of the spec is closed or formally deferred, so the agents cite a
+settled rule when proposing accept-list entries rather than embedding
+rationale inline. The same surface is what allows `vocab-drift-audit` to
+recommend retiring an entry on a spec ground instead of an ad-hoc
+judgment call.
+
+### nolte (primary maintainer)
+
+The repo's primary maintainer adds and removes vocabulary entries through
+ordinary PR flow. The MVP delivers them a self-contained reference for
+what qualifies for inclusion, what the removal policy is, and how a new
+vocabulary group is vetted — the three Open Questions whose answers most
+directly affect day-to-day curation. Once shipped, review effort goes
+into the actual edits rather than re-deriving the policy each time.
+
+## Verification
+
+Anchored on `F-1:acceptance-5`:
+
+> Every remaining bullet in the `## Open Questions` section of
+> `spec/vocabulary-and-style-curation/en.md` either disappears or carries
+> a `deferred until <event>` annotation.
+
+When this acceptance criterion is checked (per `project/features/vocabulary-curation-spec.md`),
+the spec is settled enough for downstream consumers to cite, and the MVP
+scope (R-1) is delivered.
+
+## Source
+
+- Audience artefact: `AUDIENCES.md` at the repo root, uncommitted at
+  mission write time (file co-authored in this same bootstrap session;
+  the SHA will be captured on the first commit that lands the
+  `project/` planning suite).
+- Outcomes consulted: O-5 from `project/goals.md`.
+- Operator: nolte (`git config user.name`) via `mission-define` skill,
+  commit-pending.

--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -1,0 +1,39 @@
+capabilities:
+  - name: vale-style-package
+    description: >-
+      A curated Vale style package distributed as `nolte-styles.zip` via
+      GitHub releases. Consumer repositories integrate it via a single
+      `.vale.ini` `Packages` entry to lint markdown consistently across the
+      portfolio.
+    audience:
+      - "nolte/* consumer repositories"
+      - "CI pipelines in consumer repos"
+      - "local developers in consumer repos"
+    status: active
+    rationale: >-
+      vale-style is the only nolte/* repo that ships a Vale style package
+      — the portfolio's single source of truth for shared vocabularies
+      and (future) style rules. Consolidating this into a single repo
+      prevents the vocabulary-drift problem named in
+      `spec/vocabulary-and-style-curation/en.md` Context section.
+
+  - name: vocabulary-curation-spec
+    description: >-
+      A written specification under
+      `spec/vocabulary-and-style-curation/{en,de}.md` that codifies
+      inclusion criteria, removal policy, and group scoping for the
+      vocabularies shipped in `vale-style-package`. Curator agents from
+      `nolte/claude-shared` (`prose-vale-curator`, `vocab-drift-audit`)
+      cite this spec to ground automated curation decisions.
+    audience:
+      - "nolte (primary maintainer)"
+      - "Claude Code agents / skills"
+      - "External contributors"
+    status: experimental
+    rationale: >-
+      The curation spec lives next to the package it governs; placing it
+      elsewhere would split the source of truth from the artefact and
+      re-introduce the vocabulary-drift problem the spec exists to
+      prevent. Status is `experimental` because the spec ships at
+      `Status: draft` with four Open Questions; R-1 (the MVP item)
+      promotes it to a settled state.

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+This file is the queue governed by `spec/project/roadmap/` (canonical version
+lives in `nolte/claude-shared`). Detail levels (`fine` / `coarse` / `backlog`)
+and lifecycle (`proposed → active → done | cancelled`) are enforced by the
+`roadmap-refine` and `roadmap-planner` skills. Item IDs (`R-<n>`) are
+monotonic across the project's lifetime and never reused; the next item to be
+added starts at `R-1`.
+
+Items are added via `/nolte-shared:roadmap-planner`.
+
+### R-1 — Vocabulary curation spec
+
+```yaml
+id: R-1
+title: Vocabulary curation spec
+detail: fine
+outcomes: [O-5]
+target_sprint: 1
+mvp: true
+status: proposed
+```
+
+Curator agents and external contributors find written rules for accepting or rejecting vocabulary entries instead of guessing; the existing `spec/vocabulary-and-style-curation/{en,de}.md` is taken from `Status: draft` to settled by closing all four Open Questions.
+
+- [ ] vocabulary-curation-spec

--- a/project/sprints/0001-vocabulary-curation-rules.md
+++ b/project/sprints/0001-vocabulary-curation-rules.md
@@ -1,0 +1,38 @@
+---
+number: 1
+status: planned
+started: null
+ended: null
+value_statement: Curator agents and external contributors find written rules for accepting or rejecting vocabulary entries instead of guessing.
+artifact_ref: null
+last_commit: null
+roadmap_items: [R-1]
+features: [F-1]
+---
+
+## Goal
+
+The `spec/vocabulary-and-style-curation/{en,de}.md` specification currently
+ships as `Status: draft` with four Open Questions that block downstream
+consumers (curator agents from `claude-shared`, external contributors)
+from citing it authoritatively. This sprint closes those questions so the
+spec becomes a settled reference rather than a draft one. Sprint value is
+verified by `F-1:acceptance-5` — every remaining Open Question is either
+removed or carries a `deferred until <event>` annotation.
+
+## Features
+
+- [F-1](../features/vocabulary-curation-spec.md) — status: ready
+
+## Out of scope
+
+- Authoring new vocabulary entries (no edits to
+  `src/styles/config/vocabularies/<group>/accept.txt`).
+- Authoring the first real Vale rule under `src/styles/nolte-styles/`
+  (covered by a future roadmap item, not this sprint).
+- Changing the consumer-facing `.vale.ini` shape (consumer responsibility
+  per AUDIENCES.md bounded context).
+
+## Review notes
+
+_Populated by `sprint-review` at closure._


### PR DESCRIPTION
## Summary

Bootstraps the `project/` planning artefacts plus an audience artefact at
`AUDIENCES.md` so vale-style adopts the portfolio-wide nolte-shared specs
for audience identification, roadmap, mission, sprint, feature, and
portfolio management. The first roadmap item R-1 reorients existing work
in `spec/vocabulary-and-style-curation/` to closing its four Open
Questions rather than re-authoring the spec from scratch.

## Changes

- Add `AUDIENCES.md` enumerating 12 audiences across all five
  relationship categories (direct, operator, contributor, governing,
  indirect), all `assumed` pending operator confirmation.
- Add `project/goals.md` with the project Vision and outcomes O-1..O-5.
- Add `project/roadmap.md` with the first roadmap item R-1 (Vocabulary
  curation spec, `detail: fine`, `target_sprint: 1`, `mvp: true`).
- Add `project/mission.md` with `mvp_status: defining`,
  `verifies_via: F-1:acceptance-5`, three primary audiences, and
  `time_bound: { kind: mvp_completion }`.
- Add `project/sprints/0001-vocabulary-curation-rules.md`
  (`status: planned`) bound to R-1 via F-1.
- Add `project/features/vocabulary-curation-spec.md` (F-1) with six
  acceptance criteria targeting closure of the four Open Questions in
  `spec/vocabulary-and-style-curation/en.md`; consistency-reviewer
  agent passed clean on the redesigned draft.
- Add `project/portfolio.yml` declaring two capabilities:
  `vale-style-package` (active) and `vocabulary-curation-spec`
  (experimental).

## Linked issues

None

## Testing

- `task lint` — passed locally (pre-commit hooks all green: check-yaml,
  end-of-files, trailing-whitespace).
- `python3 -c "import yaml; yaml.safe_load(open('project/portfolio.yml'))"` — passed.
- Feature-consistency-reviewer agent re-run at SHA b4ae9e0 — `kind: clean`.

## Risk / rollout notes

Documentation-only change; no impact on shipped `nolte-styles.zip` or
runtime behaviour. The `AUDIENCES.md` file is uncommitted at mission
write time and `project/mission.md` `## Source` notes this explicitly —
the next mission revision can capture the SHA. No roadmap-side `mvp:
true` items have reached `status: active`, so the
`mvp_status: defining → in_progress` flip remains pending (operator
decision via `/nolte-shared:mission-revise`).