### PR TITLE
chore(prose): vale-clean repo prose and extend technical vocabulary

### DIFF
--- a/AUDIENCES.md
+++ b/AUDIENCES.md
@@ -30,7 +30,7 @@ peripheral). A whole category is marked `none — <reason>` when it does not app
 
 ### Direct consumers
 
-- **nolte/* consumer repositories** — _category_: direct-consumer · _surface_: `.vale.ini` `Packages` entry, GitHub release URL · _expects_: stable, semver-versioned ZIP URL; runnable vocabularies; backwards-compatible vocabulary names (`technical`, `esphome`) · _status_: `assumed` · _criticality_: primary
+- **nolte/* consumer repositories** — _category_: direct-consumer · _surface_: `.vale.ini` `Packages` entry, GitHub release URL · _expects_: stable, SemVer-versioned ZIP URL; runnable vocabularies; backwards-compatible vocabulary names (`technical`, `esphome`) · _status_: `assumed` · _criticality_: primary
   - Open questions: which `nolte/*` repos actually consume this package today? Is the list discoverable via a search across `nolte/*` for `Packages = nolte-styles` style strings?
 - **CI pipelines in consumer repos** — _category_: direct-consumer · _surface_: `vale-action` or `vale .` in GitHub Actions workflows · _expects_: reproducible lint runs, no flaky vocabulary drift, no breaking changes without a major version bump · _status_: `assumed` · _criticality_: primary
   - Open questions: do consumers pin to a specific release tag, or do they float on `latest`? The answer changes the blast radius of every release.
@@ -41,7 +41,7 @@ peripheral). A whole category is marked `none — <reason>` when it does not app
 
 ### Operators
 
-- **nolte (repository maintainer)** — _category_: operator · _surface_: GitHub Releases UI, `Taskfile.yml`, `.github/workflows/release-*` · _expects_: runnable `task build` / `task test` / `task docs`; reproducible release cuts via release-drafter → `release-cd-archive.yml`; predictable semver bumps · _status_: `assumed` · _criticality_: primary
+- **nolte (repository maintainer)** — _category_: operator · _surface_: GitHub Releases UI, `Taskfile.yml`, `.github/workflows/release-*` · _expects_: runnable `task build` / `task test` / `task docs`; reproducible release cuts via release-drafter → `release-cd-archive.yml`; predictable SemVer bumps · _status_: `assumed` · _criticality_: primary
   - Open questions: none beyond ordinary release hygiene.
 - **GitHub Actions runners / platform** — _category_: operator · _surface_: workflow YAML, reusable workflows pinned to `nolte/gh-plumbing@v1.1.12` · _expects_: stable pinned versions, deterministic builds, no unpinned actions · _status_: `assumed` · _criticality_: secondary
   - Open questions: none.
@@ -59,7 +59,7 @@ peripheral). A whole category is marked `none — <reason>` when it does not app
 
 ### Governing parties
 
-- **nolte (repo owner)** — _category_: governing · _surface_: branch protection rules, `.github/settings.yml` via Probot Settings, spec approval · _expects_: veto authority on vocabulary and style changes; final say on semver-major cuts · _status_: `assumed` · _criticality_: primary
+- **nolte (repo owner)** — _category_: governing · _surface_: branch protection rules, `.github/settings.yml` via Probot Settings, spec approval · _expects_: veto authority on vocabulary and style changes; final say on SemVer-major cuts · _status_: `assumed` · _criticality_: primary
   - Open questions: none.
 - **nolte portfolio consensus** (specs under `claude-shared/spec/`) — _category_: governing · _surface_: pull-request-workflow, branching-model, release-automation, project-structure specs · _expects_: repo stays conformant; deviations propagate via spec update, not silently · _status_: `assumed` · _criticality_: primary
   - Open questions: does this repo need its own per-spec opt-out tracking, or does conformance suffice?

--- a/project/goals.md
+++ b/project/goals.md
@@ -12,7 +12,7 @@ repository.
   `.vale.ini` `Packages` entry and get a working lint setup without
   duplicating vocabularies. _(audience: nolte/\* consumer repositories)_
 - **O-2** — CI pipelines in consumer repos stay deterministic across
-  releases; vocabulary changes ship through semver-versioned release tags
+  releases; vocabulary changes ship through SemVer-versioned release tags
   rather than silent drift. _(audience: CI pipelines in consumer repos)_
 - **O-3** — Local developers see identical lint behaviour locally and in CI,
   so corrections happen before push. _(audience: local developers in consumer repos)_

--- a/src/styles/config/vocabularies/technical/accept.txt
+++ b/src/styles/config/vocabularies/technical/accept.txt
@@ -5,6 +5,7 @@ ADRs?
 Ansible
 Anthropic('s)?
 asdf
+auditability
 auditable
 [Aa]utoallow(s|ed|ing)?
 [Aa]utofix(es|ed|ing)?
@@ -15,6 +16,7 @@ automerge
 [Bb]ackend
 backlink
 basename
+[Bb]ikeshedding
 [Bb]oolean
 browsable
 [Cc]allouts
@@ -24,6 +26,7 @@ CLIs?
 closeable
 commit's
 [Cc]onfigs?
+conformant
 criteria's
 cron
 CTAs
@@ -35,6 +38,7 @@ deduplicate[ds]?
 Dependabot
 deps
 devcontainer
+discoverability
 dispatchable
 Dockerfiles?
 docstrings?


### PR DESCRIPTION
## Summary

Curator-driven prose pass that brings `vale .` to zero alerts across all
18 markdown files in the repo. Four `semver` occurrences are rephrased to
the canonical `SemVer` casing already shipped in the `technical`
vocabulary; four new entries are added to `src/styles/config/vocabularies/technical/accept.txt`
where rephrasing would strip precision.

## Changes

- Rephrase: `semver` → `SemVer` in `AUDIENCES.md` (3 occurrences) and
  `project/goals.md` (1 occurrence). The canonical brand casing is
  already mandated by `spec/vocabulary-and-style-curation/en.md` §MUST
  line 36.
- Extend `src/styles/config/vocabularies/technical/accept.txt` with
  four entries:
  - `auditability` — noun derivation of the already-accepted
    `auditable`.
  - `[Bb]ikeshedding` — precise jargon (Parkinson's Law of Triviality);
    bracket class valid for the generic sentence-position case per spec
    §MUST line 36 (no brand owner).
  - `conformant` — semantically tighter than `compliant` (structural
    conformance vs regulatory).
  - `discoverability` — parallel to the already-accepted
    `reachability`, `[Ll]inkability`, `[Rr]eviewability` patterns.

## Linked issues

None

Refs spec/vocabulary-and-style-curation/

## Testing

- `task test` (`vale .`) — passes with `0 errors, 0 warnings, 0 suggestions in 18 files`.
- `task lint` — pre-commit hooks all green.

## Upstream sources for the new vocabulary entries

(Per `spec/vocabulary-and-style-curation/en.md` §MUST line 37, which
requires the PR description to cite the upstream source for any new
vocabulary entry.)

- `auditability` — Merriam-Webster, standard English noun.
- `[Bb]ikeshedding` — Wikipedia: "Law of triviality"
  (https://en.wikipedia.org/wiki/Law_of_triviality). Standard English
  jargon; no brand owner.
- `conformant` — Merriam-Webster, standard English adjective.
- `discoverability` — Merriam-Webster / Oxford, standard English noun.

## Risk / rollout notes

Curator-only PR; no application or build code touched. Shipped artefact
(`nolte-styles.zip`) gains four `technical/accept.txt` entries, so the
package's release-cd-archive workflow will rebuild and republish on the
next release. No existing entries removed; consumer repos see additive
changes only. No new vocabulary group introduced, so
`spec/vocabulary-and-style-curation/en.md` §MUST line 38 (docs sync) is
not triggered.