### PR TITLE
chore(workflows): wire reusable-* callers to portfolio-app token cascade

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -19,9 +19,12 @@ on:
 
 jobs:
   automerge:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-automerge.yaml@v1.1.18
+    with:
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/build-static-tests.yaml
+++ b/.github/workflows/build-static-tests.yaml
@@ -3,16 +3,16 @@ on:
 
 jobs:
   static:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-pre-commit.yaml@v1.1.18
 
   security:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-trivy.yaml@v1.1.18
     permissions:
       contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
   chain-bench:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-chain-bench.yaml@v1.1.18
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -20,5 +20,7 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       dry_run: ${{ inputs.dry_run }}
+      app-id: ${{ vars.PORTFOLIO_APP_ID }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-private-key: ${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -8,4 +8,4 @@ permissions:
 
 jobs:
   spelling:
-    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.12
+    uses: nolte/gh-plumbing/.github/workflows/reusable-spelling-vale.yaml@v1.1.18


### PR DESCRIPTION
## Summary

Bring all reusable-workflow callers under \`.github/workflows/\` to
\`gh-plumbing@v1.1.18\` and onto the App-installation-token cascade
(issue [#330](https://github.com/nolte/gh-plumbing/issues/330)).

\`release-publish.yml\` was already on \`v1.1.18\` but missing the App
credential passthrough; this PR adds it so the publish call runs under
the App identity.

## Changes

- \`automerge.yaml\`: pin \`v1.1.12 → v1.1.18\`; pass
  \`app-id: \${{ vars.PORTFOLIO_APP_ID }}\` and
  \`secrets.app-private-key: \${{ secrets.PORTFOLIO_APP_PRIVATE_KEY }}\`.
- \`build-static-tests.yaml\`: pin \`v1.1.12 → v1.1.18\` on three
  reusables (pre-commit, trivy, chain-bench).
- \`spelling.yaml\`: pin \`v1.1.12 → v1.1.18\`.
- \`release-publish.yml\`: add App credentials to a caller that was
  already at v1.1.18.

\`release-cd-archive.yml\` (vale-style-specific archiver via
\`ncipollo/release-action\`) is intentionally not touched.

## Linked issues

\`nolte/gh-plumbing#330\` — App-installation-token cascade.

## Risk / rollout notes

Pure CI wiring. App credentials are already in place on this repo via
\`terraform/portfolio-app/\` in \`nolte/terraform-github-bootstrap\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)