### PR TITLE
chore(vocab): add [Aa]gents? to technical accept list

### DIFF
--- a/src/styles/config/vocabularies/technical/accept.txt
+++ b/src/styles/config/vocabularies/technical/accept.txt
@@ -1,6 +1,7 @@
 ACs?
 achievability
 ADRs?
+[Aa]gents?
 [Aa]llowlist
 Ansible
 Anthropic('s)?


### PR DESCRIPTION
## Summary

Adds `[Aa]gents?` to `src/styles/config/vocabularies/technical/accept.txt` so Vale stops flagging the term `agent` (and its variants) as a `Microsoft.Terms` violation across consumer repositories.

## Changes

- Add `[Aa]gents?` entry to `src/styles/config/vocabularies/technical/accept.txt` (alphabetical placement between `ADRs?` and `[Aa]llowlist`)

## Linked issues

None

## Testing

- `task --yes lint`: pre-commit hooks pass
- Single-line addition follows the existing case-variation pattern (`[Aa]gents?`) used throughout the file

## Risk / rollout notes

Vocabulary-only change, no rule or behavioural impact. Lands once `nolte/vale-style` cuts the next release tag; downstream consumers pick it up via their pinned vale-style version (`vale sync`).

## Why

`agent` is a load-bearing Claude Code identifier (`agents/<name>.md`, "skill or agent", "Claude Agent") used across the `nolte` portfolio's spec corpus and skill/agent prose. `Microsoft.Terms` currently flags every occurrence and suggests "personal digital assistant", which is semantically wrong for this domain. Identified by the `prose-vale-curator` agent during vale-clean of nolte/claude-shared#167 (portfolio-inflight-management spec); the same warning appears in the existing `portfolio-management` spec and across the `claude/*` spec topic.