### PR TITLE
chore(vocab): add eight cross-project terms to technical accept list

### DIFF
--- a/src/styles/config/vocabularies/technical/accept.txt
+++ b/src/styles/config/vocabularies/technical/accept.txt
@@ -5,6 +5,7 @@ ADRs?
 [Aa]llowlist
 Ansible
 Anthropic('s)?
+APIs?
 asdf
 auditability
 auditable
@@ -27,6 +28,7 @@ CLIs?
 closeable
 commit's
 [Cc]onfigs?
+[Cc]ookiecutter
 conformant
 criteria's
 cron
@@ -59,6 +61,8 @@ gitignored
 Graphviz
 hoc
 hotfix(es)?
+idempotency
+[Ii]nlining
 [Ii]nspectable
 invocable
 Jira
@@ -70,6 +74,7 @@ lookups?
 lowercased
 Midjourney
 misclassification
+mitigations
 MkDocs
 [Mm]onorepos?
 MRs
@@ -108,8 +113,10 @@ rollout
 [Rr]outable
 runbooks?
 runtimes
+[Ss]cannability
 [Ss]caffold(s|ed|ing)?
 SemVer
+[Ss]kimmable
 severities
 SHAs
 SHOULDs
@@ -144,6 +151,7 @@ validator(s|'s)?
 [Vv]ectoris(e|er|ers|ing|ed)?
 vendoring
 venv
+virtualenv
 Vitest
 vtracer
 [Ww]orktree(s|'s)?


### PR DESCRIPTION
## Summary

Adds eight cross-project technical terms to the `technical` vocabulary group. These terms are already in use in `nolte/claude-shared` prose and currently live as a repository-local override there (added in `nolte/claude-shared` PR #112 to unblock lint). Per `spec/project/prose-style/` §New terms and phrasings, newly coined terms belong in the shared `nolte/vale-style` vocabulary rather than per-repo; once this lands and a release is cut, the downstream local entries are removed and the pin is bumped.

All eight are generic English / tooling words flagged by Vale's base dictionary, none are brand names, and each follows the spec's case policy (bracket-class for sentence-position case variance, plain lowercase/uppercase otherwise).

## Changes

Added to `src/styles/config/vocabularies/technical/accept.txt` (one-line justification per entry):

- `APIs?` — common acronym for "application programming interface"; uppercase canonical, optional plural.
- `[Cc]ookiecutter` — the project-templating tool/term; bracket-class covers sentence-initial casing.
- `idempotency` — standard distributed-systems / API property noun.
- `[Ii]nlining` — common code/docs verb-noun for moving content inline; bracket-class covers sentence position.
- `mitigations` — standard security / risk term.
- `[Ss]cannability` — documentation-quality term (how easily prose can be scanned); bracket-class covers sentence position.
- `[Ss]kimmable` — Write-the-Docs documentation principle; bracket-class covers sentence position.
- `virtualenv` — the Python virtual-environment tool; always lowercase.

Entries inserted in their alphabetical neighbourhoods within the existing list.

## Linked issues

Refs nolte/claude-shared#115

## Testing

- `accept.txt` contains only regex entries, no blank or comment lines (verified).
- No duplicate entries introduced (159 total, all unique).

## Risk / rollout notes

Vocabulary-only addition; widens what Vale accepts, so it cannot newly fail any consumer's lint. After merge, a `nolte/vale-style` release lets `nolte/claude-shared` drop the corresponding local override entries and bump its pin.