### PR TITLE
feat(portfolio): capture tech_stack block (deploy-target + plugin override)

### DIFF
--- a/project/portfolio.yml
+++ b/project/portfolio.yml
@@ -37,3 +37,29 @@ capabilities:
       prevent. Status is `experimental` because the spec ships at
       `Status: draft` with four Open Questions; R-1 (the MVP item)
       promotes it to a settled state.
+
+# Schema for tech_stack: spec/portfolio/tech-stack/ §Per-repository tech-stack block.
+# Inherits the global stack from claude-shared:portfolio/tech-stack.yml; only the
+# per-repo deltas below are declared here.
+tech_stack:
+  additions:
+    - name: github-releases
+      kind: deploy-target
+      group: automation
+      lifecycle: runtime
+      role: >-
+        Delivers the nolte-styles.zip Vale style package as a GitHub release
+        asset, built and attached by the release-cd-archive workflow.
+      status: active
+      source_of_truth: .github/workflows/release-cd-archive.yml
+      rationale: >-
+        acknowledged-missing-signal: GitHub Releases is vale-style's delivery
+        channel for the style package; kind deploy-target is operator-curated
+        and never auto-emitted by the discovery probe.
+
+  overrides:
+    - name: claude-code-plugin
+      inherit: false
+      rationale: >-
+        vale-style ships a Vale style package, not a Claude Code plugin; it
+        carries no .claude-plugin/ manifests and no skills/agents layout.


### PR DESCRIPTION
## Summary

Adds the `tech_stack:` block to `project/portfolio.yml`, resolving Suggestion **S2** from the 2026-06-02 portfolio audit (nolte/claude-shared `.audits/portfolio/2026-06-02.md`). vale-style was the only Portfolio-Member whose manifest carried no `tech_stack:` block.

## Changes

- **additions** — `github-releases` (`kind: deploy-target`): the `nolte-styles.zip` style package is delivered as a GitHub release asset by `release-cd-archive`. Operator-curated (deploy-target is never auto-emitted), carries the `acknowledged-missing-signal:` marker.
- **overrides** — `claude-code-plugin` (`inherit: false`): vale-style is a Vale style package, not a Claude Code plugin.
- Everything else (task, renovate, github-actions, pre-commit, vale, mkdocs, release-drafter, probot-settings, boring-cyborg, stale-bot) is inherited from the global stack unchanged.

## Linked issues

None

## Testing

- `tech_stack:` validated locally against the kind/group/status/lifecycle enums and the override (`inherit: false` + non-empty rationale) rule from `spec/portfolio/tech-stack/`.

## Risk / rollout notes

Low — additive manifest metadata; no code or workflow change.