### PR TITLE
chore(vocab): add [Cc]hezmoi to technical accept list

### DIFF
--- a/src/styles/config/vocabularies/technical/accept.txt
+++ b/src/styles/config/vocabularies/technical/accept.txt
@@ -39,6 +39,7 @@ bundlers?
 [Bb]ypassable
 [Cc]allouts?
 Carliner
+[Cc]hezmoi
 Chissom
 CI
 Claude


### PR DESCRIPTION
## Summary

Adds `[Cc]hezmoi` to the `technical` vocabulary's accept list so Vale stops flagging the tool name `chezmoi` as a misspelling across the portfolio.

## Why

`chezmoi` (https://www.chezmoi.io/) is the dotfile manager at the centre of [`nolte/workstation`](https://github.com/nolte/workstation). `Vale.Spelling` currently fires on every mention of it in that repo's `README.md` and `docs/` because the term is missing from the upstream vocabulary — while sibling provisioning-stack terms (`asdf`, `[Dd]otfiles?`, `Taskfiles?`, `zsh`, `MkDocs`) are already accepted. This surfaced during an editorial Lektorat pass on nolte/workstation#84, where `chezmoi` was the only remaining false-positive that couldn't be resolved repo-locally (the synced accept list is the upstream package).

## Changes

- `src/styles/config/vocabularies/technical/accept.txt`: insert `[Cc]hezmoi` in alphabetical order (between `Carliner` and `Chissom`).

The bracketed form covers lowercase prose use and sentence-start capitalisation; the tool's canonical name is lowercase.

## Follow-up (downstream, not this PR)

Once this lands and a release is cut, `nolte/workstation` bumps its pinned `nolte/vale-style` tag in `.vale.ini` (currently `v0.1.3`) to pick up both this entry and `nolte`, which is already accepted upstream as of `v0.1.14`.