### PR TITLE
docs(glossary): add a bilingual glossary covering every vocabulary entry

### DIFF
--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -1,0 +1,883 @@
+# Glossar
+
+Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Einträge sind nach denselben Familien gruppiert wie auf der Seite [Vokabulare](vocabularies.md) und über ihr lesbares Lemma aufgeführt — der zugrunde liegende `accept.txt`-Eintrag ist oft eine Regex, die auch Plural- und andere Beugungsformen abdeckt (siehe [wie das Matching funktioniert](vocabularies.md#wie-eintrage-gematcht-werden)). Marken- und Produktnamen tragen einen kurzen Einordnungssatz statt einer vollen Definition.
+
+## Vokabular `technical`
+
+### Werkzeuge, Produkte und Marken
+
+`Ansible`
+:   Agentenloses Werkzeug für IT-Automatisierung und Konfigurationsmanagement.
+
+`Anthropic`
+:   KI-Sicherheitsunternehmen, das die Claude-Modelle entwickelt.
+
+`asdf`
+:   Versionsmanager, der über eine einzige CLI mehrere Sprach-Runtimes verwaltet.
+
+`Astro`
+:   Web-Framework für content-getriebene Seiten, das minimales clientseitiges JavaScript ausliefert.
+
+`Atlassian`
+:   Softwarehersteller hinter Jira, Confluence und Bitbucket.
+
+`Bun`
+:   Schnelle All-in-one-JavaScript-Runtime, Bundler und Paketmanager.
+
+`chezmoi`
+:   Dotfile-Manager für mehrere Maschinen.
+
+`Claude`
+:   Anthropics Familie großer Sprachmodelle.
+
+`Contentful`
+:   API-first Headless-Content-Management-System.
+
+`cookiecutter`
+:   Scaffolding-Werkzeug, das aus Antworten eine Projektvorlage rendert.
+
+`dayjs`
+:   Minimalistische JavaScript-Bibliothek für Datum und Zeit.
+
+`Dependabot`
+:   GitHub-Bot, der Pull Requests zur Aktualisierung von Abhängigkeiten öffnet.
+
+`Deque`
+:   Unternehmen für Accessibility-Werkzeuge, Urheber der axe-Engine.
+
+`DOMPurify`
+:   Clientseitiger HTML-Sanitizer, der XSS-anfälliges Markup entfernt.
+
+`Eleventy`
+:   Static-Site-Generator, auch „11ty" geschrieben.
+
+`ESLint`
+:   Erweiterbarer Linter für JavaScript und TypeScript.
+
+`ESPHome`
+:   Framework, das Firmware für ESP-basierte Geräte baut, häufig mit Home Assistant.
+
+`Figma`
+:   Browserbasiertes, kollaboratives Werkzeug für Interface-Design.
+
+`gh-plumbing`
+:   noltes geteiltes Repository mit wiederverwendbaren GitHub-Actions-Workflows und Probot-Konfigurationen.
+
+`godoc`
+:   Dokumentationsgenerator von Go.
+
+`Grammarly`
+:   Kommerzieller Schreibassistent und Grammatikprüfer.
+
+`Graphviz`
+:   Toolkit zur Graph-Visualisierung, gesteuert über die Sprache DOT.
+
+`Inkbot`
+:   Drittanbieter-Designstudio bzw. -marke, auf die in den Asset-Specs verwiesen wird.
+
+`Jira`
+:   Atlassians Werkzeug zur Vorgangs- und Projektverfolgung.
+
+`JUnit`
+:   Java-Unit-Test-Framework, dessen XML-Reportformat ein CI-Standard ist.
+
+`Mailchimp`
+:   Plattform für E-Mail-Marketing und Newsletter.
+
+`Mantine`
+:   React-Bibliothek für Komponenten und Hooks.
+
+`Midjourney`
+:   Generativer KI-Bilddienst.
+
+`MkDocs`
+:   Static-Site-Generator für Projektdokumentation, hier mit dem Material-Theme genutzt.
+
+`MUI`
+:   Material UI, eine React-Komponentenbibliothek, die Material Design umsetzt.
+
+`mypy`
+:   Statischer Typprüfer für Python.
+
+`nginx`
+:   Performanter Webserver und Reverse Proxy.
+
+`nolte`
+:   Der GitHub-Account, der dieses Paket veröffentlicht.
+
+`notistack`
+:   React-Bibliothek zum Stapeln von Snackbar-Benachrichtigungen.
+
+`npm`
+:   Standard-Paketmanager und -Registry für Node.js.
+
+`Numonic`
+:   Drittanbieter-Marke, auf die in den Specs des Projekts verwiesen wird.
+
+`Probot`
+:   Framework zum Bau von GitHub Apps; trägt die geteilten Settings- und Labelling-Bots.
+
+`Pyright`
+:   Microsofts statischer Typprüfer für Python.
+
+`Recharts`
+:   React-Charting-Bibliothek auf Basis von D3.
+
+`Renovate`
+:   Werkzeug zur automatisierten Aktualisierung von Abhängigkeiten, hier über ein geteiltes Preset konfiguriert.
+
+`Shiki`
+:   Syntax-Highlighter, der TextMate-Grammatiken und Editor-Themes nutzt.
+
+`Skywork`
+:   Drittanbieter-KI-Modell bzw. -Dienst, auf den im Projekt verwiesen wird.
+
+`Supabase`
+:   Quelloffene Backend-Plattform auf Basis von PostgreSQL.
+
+`Tailwind`
+:   Utility-first-CSS-Framework.
+
+`Taskfile`
+:   Konfigurationsdatei für den Task-Runner go-task (`task`).
+
+`Tauri`
+:   Framework zum Bau von Desktop-Apps mit Web-Frontend und Rust-Kern.
+
+`textstat`
+:   Python-Bibliothek, die Lesbarkeitsmetriken berechnet.
+
+`Trivy`
+:   Quelloffener Security- und Schwachstellen-Scanner.
+
+`typedoc`
+:   Dokumentationsgenerator für TypeScript.
+
+`Ulanzi`
+:   Consumer-Hardware-Marke, z. B. die in manchen Configs genutzte Smart-Pixel-Uhr.
+
+`Vercel`
+:   Hosting- und Deployment-Plattform, Urheber von Next.js.
+
+`Vite`
+:   Schnelles Frontend-Build-Werkzeug und Dev-Server.
+
+`Vitest`
+:   Vite-natives Unit-Test-Framework.
+
+`vtracer`
+:   Werkzeug, das Rasterbilder in SVG-Vektoren umwandelt.
+
+`Vue`
+:   Progressives JavaScript-Framework zum Bau von Benutzeroberflächen.
+
+`Webheads`
+:   Drittanbieter-Marke bzw. -Community, auf die im Projekt verwiesen wird.
+
+`Zod`
+:   TypeScript-first-Bibliothek zur Schema-Deklaration und -Validierung.
+
+`zsh`
+:   Die Z-Shell, eine interaktive Unix-Shell.
+
+### Begriffe aus Software-Engineering, CI/CD, Security und Dokumentation
+
+`AC`
+:   Akzeptanzkriterium — eine Bedingung, die eine Änderung erfüllen muss, um als fertig zu gelten (Plural ACs).
+
+`addon`
+:   Eine Komponente, die eine Host-Anwendung erweitert.
+
+`ADR`
+:   Architecture Decision Record — eine kurze Notiz, die eine Architekturentscheidung und ihre Begründung festhält.
+
+`affordance`
+:   Ein Gestaltungshinweis, der signalisiert, wie ein Element benutzt werden kann.
+
+`agentic`
+:   Beschreibt Software, typischerweise LLM-gesteuert, die eigenständig Ziele verfolgt.
+
+`agent`
+:   Ein autonomes Programm, das Aufgaben im Auftrag eines Nutzers erledigt.
+
+`allowlist`
+:   Eine explizite Menge erlaubter Einheiten; das einschließende Gegenstück zur Denylist.
+
+`API`
+:   Application Programming Interface — ein definierter Vertrag zwischen Softwarekomponenten.
+
+`async`
+:   Asynchron — den Aufrufer nicht blockierend, während eine Operation läuft.
+
+`attestable`
+:   Kryptografisch bezeugbar.
+
+`attestation`
+:   Eine signierte Aussage über Herkunft oder Integrität eines Artefakts, etwa Build-Provenance.
+
+`auditability`
+:   Das Maß, in dem die Aktionen eines Systems im Nachhinein überprüfbar sind.
+
+`auditable`
+:   Überprüfbar und gegen einen Nachweis abgleichbar.
+
+`autofix`
+:   Eine automatisch angewandte Korrektur für einen Lint- oder Build-Befund.
+
+`autofocus`
+:   HTML-Attribut, das ein Eingabefeld beim Laden der Seite fokussiert.
+
+`automerge`
+:   Das automatische Mergen eines Pull Requests, sobald alle erforderlichen Checks grün sind.
+
+`backend`
+:   Der serverseitige Teil einer Anwendung.
+
+`backlink`
+:   Ein Link, der auf eine verweisende Seite zurückzeigt.
+
+`bluetooth`
+:   Standard für drahtlose Verbindung über kurze Distanz.
+
+`boolean`
+:   Ein Wert, der entweder wahr oder falsch ist.
+
+`bundler`
+:   Ein Werkzeug, das Quellmodule zu auslieferbaren Bundles zusammenfasst.
+
+`callout`
+:   Ein optisch hervorgehobener Hinweis bzw. eine Admonition in der Dokumentation.
+
+`CI`
+:   Continuous Integration — das automatische Bauen und Testen jeder Änderung.
+
+`CLI`
+:   Command-Line Interface (Kommandozeilen-Schnittstelle).
+
+`closeable`
+:   Schließbar, etwa eine freigebbare Ressource.
+
+`conformant`
+:   Einer Spezifikation oder einem Standard entsprechend.
+
+`cron`
+:   Zeitbasierter Job-Scheduler; auch die Syntax seiner Zeitpläne.
+
+`CSP`
+:   Content Security Policy — ein HTTP-Header, der einschränkt, was eine Seite laden darf.
+
+`CTA`
+:   Call To Action — eine Aufforderung, die zum nächsten Schritt bewegt.
+
+`CVE`
+:   Common Vulnerabilities and Exposures — eine öffentliche Kennung für eine Sicherheitslücke.
+
+`debounce`
+:   Schnelle, wiederholte Ereignisse erst behandeln, wenn sie sich beruhigt haben.
+
+`dedup`
+:   Kurzform von deduplicate.
+
+`deduplicate`
+:   Doppelte Einträge entfernen.
+
+`denylist`
+:   Eine explizite Menge blockierter Einheiten; Gegenstück zur Allowlist.
+
+`devcontainer`
+:   Eine per Container definierte, reproduzierbare Entwicklungsumgebung.
+
+`diataxis`
+:   Ein Dokumentations-Framework, das Doku in Tutorials, How-tos, Referenz und Erklärung unterteilt.
+
+`dialog`
+:   Ein modales oder nicht-modales Fenster, das zur Eingabe oder Bestätigung auffordert.
+
+`diffable`
+:   Zeilenweise als Diff vergleichbar.
+
+`Dockerfile`
+:   Eine Textanleitung, die beschreibt, wie ein Container-Image gebaut wird.
+
+`docstring`
+:   Ein in den Quellcode eingebetteter Dokumentationsstring.
+
+`enum`
+:   Aufzählung — ein Typ mit einer festen Menge benannter Werte.
+
+`favicon`
+:   Das kleine Icon, das ein Browser für eine Seite anzeigt.
+
+`focusable`
+:   Fähig, Tastaturfokus zu erhalten.
+
+`formatter`
+:   Ein Werkzeug, das Code auf einen einheitlichen Stil umschreibt.
+
+`frontend`
+:   Der clientseitige, nutzerseitige Teil einer Anwendung.
+
+`frontmatter`
+:   Der Metadatenblock, oft YAML, am Anfang einer Markdown-Datei.
+
+`geoblocking`
+:   Das Beschränken des Zugriffs auf Inhalte nach geografischer Region.
+
+`gerund`
+:   Die `-ing`-Form eines Verbs, die als Substantiv verwendet wird.
+
+`GHSA`
+:   Kennung eines GitHub Security Advisory.
+
+`Guillemets`
+:   Winkelförmige Anführungszeichen (« »).
+
+`HMAC`
+:   Hash-based Message Authentication Code — eine schlüsselbasierte Integritäts- und Echtheitsprüfung.
+
+`hoc`
+:   Higher-Order Component — eine React-Funktion, die eine Komponente umhüllt, um Verhalten zu ergänzen.
+
+`hotfix`
+:   Eine dringende Korrektur, die direkt auf eine veröffentlichte Version angewandt wird.
+
+`idempotency`
+:   Die Eigenschaft, dass das Wiederholen einer Operation dasselbe Ergebnis liefert wie ihr einmaliges Ausführen.
+
+`idempotently`
+:   Auf idempotente Weise.
+
+`implementor`
+:   Wer eine Spezifikation umsetzt, auch „implementer" geschrieben.
+
+`inlining`
+:   Eine Definition direkt an ihrer Verwendungsstelle einsetzen.
+
+`inspectable`
+:   Zur Laufzeit oder per Werkzeug untersuchbar.
+
+`lede`
+:   Der Einstieg eines Artikels, der dessen Kernaussage nennt; Plural ledes.
+
+`lockfile`
+:   Eine Datei, die exakt aufgelöste Abhängigkeitsversionen festschreibt.
+
+`lookup`
+:   Das Abrufen eines Werts über einen Schlüssel.
+
+`lossy`
+:   Information verwerfend, wie bei verlustbehafteter Kompression.
+
+`memoise`
+:   Das Ergebnis einer Funktion für wiederholte gleiche Eingaben zwischenspeichern.
+
+`mergeable`
+:   Konfliktfrei mergebar.
+
+`misclassification`
+:   Die Zuordnung von etwas zur falschen Kategorie.
+
+`mitigation`
+:   Eine Maßnahme, die Wahrscheinlichkeit oder Auswirkung eines Risikos senkt.
+
+`monorepo`
+:   Ein einzelnes Repository, das viele Projekte enthält.
+
+`MR`
+:   Merge Request — GitLabs Bezeichnung für einen Pull Request.
+
+`MUSTs` / `SHOULDs`
+:   Pluralisierte RFC-2119-Anforderungsschlüsselwörter.
+
+`Newswire`
+:   Ein Dienst, der Nachrichtenmeldungen an Redaktionen verteilt.
+
+`NFR`
+:   Non-Functional Requirement — eine Qualitätsanforderung wie Performance oder Security.
+
+`OAuth`
+:   Offener Standard für delegierte Autorisierung.
+
+`OQ`
+:   Open Question — ein in einer Spec festgehaltener offener Punkt.
+
+`parseable`
+:   Parsebar.
+
+`postcondition`
+:   Eine Bedingung, die nach einer Operation garantiert gilt.
+
+`preload`
+:   Eine Ressource vorab laden, bevor sie benötigt wird.
+
+`PR`
+:   Pull Request — eine zur Review und zum Merge eingereichte Änderung.
+
+`px`
+:   CSS-Pixel-Einheit.
+
+`PYSEC`
+:   Kennung für ein Security-Advisory im Python-Ökosystem.
+
+`queryable`
+:   Abfragbar.
+
+`querystring`
+:   Der `key=value`-Teil einer URL nach dem `?`.
+
+`reachability`
+:   Ob ein Knoten oder Zustand von einem anderen aus erreichbar ist.
+
+`rebase`
+:   Commits auf eine neue Basis verschieben; auch rebases, rebasing.
+
+`reflog`
+:   Gits Protokoll darüber, wohin Referenzen gezeigt haben (`git reflog`).
+
+`reusable`
+:   In anderem Kontext wiederverwendbar.
+
+`runbook`
+:   Eine dokumentierte Prozedur zum Betreiben oder Wiederherstellen eines Systems.
+
+`runtime`
+:   Die Umgebung, in der ein Programm ausgeführt wird; Plural runtimes.
+
+`sandboxing`
+:   Code so isolieren, dass er den Host nicht über eine erlaubte Grenze hinaus beeinflusst.
+
+`scannability`
+:   Wie leicht sich Text mit dem Auge überfliegen lässt.
+
+`SemVer`
+:   Semantic Versioning — das Schema `MAJOR.MINOR.PATCH`.
+
+`severity`
+:   Die abgestufte Schwere eines Befunds oder Vorfalls; Plural severities.
+
+`SHA`
+:   Secure Hash Algorithm; häufig ein Git-Commit-Hash.
+
+`SLA`
+:   Service-Level Agreement.
+
+`snackbar`
+:   Eine kurze, nicht-blockierende Benachrichtigung an einem Bildschirmrand.
+
+`sref`
+:   Midjourneys Parameter für Stilreferenzen (`--sref`).
+
+`SRE`
+:   Site Reliability Engineering bzw. ein Site Reliability Engineer.
+
+`Subresource`
+:   Eine Ressource, die eine Seite zusätzlich zu sich selbst lädt, wie bei Subresource Integrity.
+
+`stylers`
+:   Komponenten oder Werkzeuge, die visuelle Gestaltung anwenden.
+
+`symbolication`
+:   Das Rückführen von Speicheradressen eines Absturzes auf Quellcode-Symbole.
+
+`teardown`
+:   Aufräumarbeiten nach einem Test oder Prozess.
+
+`thresholding`
+:   Das Anwenden eines Schwellenwerts zum Klassifizieren oder Filtern.
+
+`tooltip`
+:   Ein kleiner Hinweis, der bei Hover oder Fokus erscheint.
+
+`typecheck`
+:   Ein Programm gegen seine Typregeln prüfen.
+
+`unparseable`
+:   Nicht parsebar.
+
+`validator`
+:   Eine Komponente, die Eingaben gegen Regeln prüft.
+
+`viewport`
+:   Der sichtbare Bereich einer Seite im Browser.
+
+`wordmark`
+:   Ein Logo, das als gestalteter Schriftzug umgesetzt ist.
+
+`worktree`
+:   Ein verknüpftes Arbeitsverzeichnis eines Git-Repositories.
+
+`YAML`
+:   YAML Ain't Markup Language — ein menschenlesbares Datenserialisierungsformat.
+
+### Begriffe zu Benennung, Lebenszyklus und Workflow
+
+`achievability`
+:   Ob ein Ziel realistisch erreichbar ist — das „A" in SMART.
+
+`autoallow`
+:   Etwas automatisch erlauben, ohne manuelle Freigabe.
+
+`autodetect`
+:   Automatisch erkennen, ohne explizite Konfiguration.
+
+`autolink`
+:   Eine Referenz automatisch in einen Hyperlink umwandeln.
+
+`autoload`
+:   Bei Bedarf automatisch laden.
+
+`automatable`
+:   Automatisierbar.
+
+`auto-tag`
+:   Automatisch ein Tag vergeben.
+
+`bikeshedding`
+:   Unverhältnismäßig viel Aufwand in nebensächliche Details stecken.
+
+`browsable`
+:   Durchstöberbar.
+
+`bypassable`
+:   Umgehbar.
+
+`definitionally`
+:   Per Definition.
+
+`disambiguation`
+:   Das Auflösen, welche von mehreren Bedeutungen gemeint ist.
+
+`discoverability`
+:   Wie leicht sich etwas auffinden lässt.
+
+`dispatchable`
+:   Dispatchbar, d. h. an einen Handler routbar.
+
+`dogfood`
+:   Das eigene Produkt intern selbst nutzen; dogfooding.
+
+`favouriting`
+:   Das Markieren eines Elements als Favorit.
+
+`invocable`
+:   Aufrufbar, auch „invokable".
+
+`kebab`
+:   Wie in kebab-case — kleingeschriebene, durch Bindestriche verbundene Wörter.
+
+`linkability`
+:   Wie leicht sich Elemente miteinander verlinken lassen.
+
+`mandatoriness`
+:   Das Maß, in dem etwas verpflichtend ist.
+
+`namespace`
+:   Ein benannter Geltungsbereich, der Bezeichner eindeutig macht; namespaced.
+
+`onboarding`
+:   Einen neuen Nutzer, Beitragenden oder ein Repo auf den aktuellen Stand bringen.
+
+`operationalize`
+:   Ein Konzept in eine konkrete, ausführbare Prozedur überführen.
+
+`overridable`
+:   Überschreibbar.
+
+`rebalancing`
+:   Last oder Zuteilung neu verteilen.
+
+`recalibrated`
+:   Auf eine korrekte Referenz zurückjustiert.
+
+`rephrase`
+:   Mit anderen Worten neu formulieren.
+
+`repointing`
+:   Eine Referenz auf ein neues Ziel umlenken.
+
+`repurpose`
+:   Etwas für einen neuen Zweck anpassen.
+
+`retarget`
+:   Das beabsichtigte Ziel ändern.
+
+`retconning`
+:   Etablierte Fakten nachträglich ändern.
+
+`reviewability`
+:   Wie leicht sich eine Änderung reviewen lässt.
+
+`revisitable`
+:   Erneut aufsuchbar.
+
+`roadmap`
+:   Eine geplante Abfolge künftiger Arbeit; Plural roadmaps.
+
+`rollout`
+:   Die gestufte Veröffentlichung einer Änderung.
+
+`routable`
+:   An ein Ziel routbar.
+
+`scaffold`
+:   Ein Startgerüst aus Dateien erzeugen; scaffolding.
+
+`slugification`
+:   Das Umwandeln einer Zeichenkette in einen URL-tauglichen Slug.
+
+`subagent`
+:   Ein Agent, der von einem anderen Agenten beauftragt wird.
+
+`subfolder`
+:   Ein verschachtelter Ordner.
+
+`submodule`
+:   Ein in einem anderen eingebettetes Repository (ein Git-Submodul).
+
+`subproject`
+:   Ein in einem größeren Projekt verschachteltes Projekt.
+
+`subroot`
+:   Ein verschachteltes Wurzelverzeichnis innerhalb eines Baums.
+
+`subtask`
+:   Eine Aufgabe, die Teil einer größeren ist.
+
+`toolchain`
+:   Die Gesamtheit der Werkzeuge zum Bauen und Ausliefern von Software.
+
+`triage`
+:   Elemente nach Priorität sortieren; triaged, triaging, triages.
+
+`triggerer`
+:   Der Akteur oder das Ereignis, das etwas auslöst.
+
+`underperforming`
+:   Unter der Erwartung abschneidend.
+
+`unreviewed`
+:   Noch nicht reviewt.
+
+`untriaged`
+:   Noch nicht triagiert.
+
+`upgrader`
+:   Ein Werkzeug oder Akteur, der Upgrades durchführt.
+
+`upstreamed`
+:   An die Upstream-Quelle zurückgegeben.
+
+`vectorise`
+:   In eine Vektordarstellung umwandeln.
+
+`vendor`
+:   Den Quellcode einer Abhängigkeit ins Repo kopieren; vendored, vendoring.
+
+`virtualise`
+:   Eine virtuelle Version von etwas erzeugen.
+
+`prepended`
+:   Am Anfang hinzugefügt.
+
+### Eigennamen — Quellen aus Schreiben, Lesbarkeit und Barrierefreiheit
+
+Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in den Specs des Projekts zu Lesbarkeit, redaktionellem Stil und Barrierefreiheit auftauchen; die drei Begriffe zur Farbwahrnehmung stammen aus dem Bereich Barrierefreiheit.
+
+`Bamberger`
+:   Mitbegründer der deutschsprachigen Lesbarkeitsforschung, gemeinsam mit Vanecek.
+
+`Carliner`
+:   Saul Carliner, Autor im Bereich technische Kommunikation.
+
+`Chissom`
+:   Mitautor der Flesch-Kincaid-Klassenstufen-Studie.
+
+`Desrosiers`
+:   Nachname, der als Quelle in den Specs zu Lesbarkeit/Schreiben zitiert wird.
+
+`Fishburne`
+:   Mitautor der Flesch-Kincaid-Klassenstufen-Studie.
+
+`Flesch`
+:   Rudolf Flesch, Urheber des Flesch-Reading-Ease-Werts.
+
+`Kalzumeus`
+:   Blog und Handle des Software-Autors Patrick McKenzie.
+
+`Kincaid`
+:   J. P. Kincaid, Mitentwickler der Flesch-Kincaid-Lesbarkeitsmetrik.
+
+`Kissane`
+:   Erin Kissane, Autorin im Bereich Content-Strategie.
+
+`Lannon`
+:   John Lannon, Lehrbuchautor für technisches Schreiben.
+
+`Matuschak`
+:   Andy Matuschak, bekannt für Arbeiten zu Notizen und Wissenswerkzeugen.
+
+`Stockton`
+:   Nachname, der als Quelle in den Specs zu Schreiben/Lesbarkeit zitiert wird.
+
+`Strunk`
+:   William Strunk Jr., Mitautor von „The Elements of Style".
+
+`Vanecek`
+:   Mitbegründer der deutschsprachigen Lesbarkeitsforschung, gemeinsam mit Bamberger.
+
+`Zinsser`
+:   William Zinsser, Autor von „On Writing Well".
+
+`deutan`
+:   Farbsehschwäche, die die Grünwahrnehmung betrifft (Deuteranopie-Familie).
+
+`protan`
+:   Farbsehschwäche, die die Rotwahrnehmung betrifft (Protanopie-Familie).
+
+`tritan`
+:   Farbsehschwäche, die die Blauwahrnehmung betrifft (Tritanopie-Familie).
+
+### Shell- und Runtime-Kürzel
+
+`basename`
+:   Die letzte Komponente eines Dateipfads.
+
+`config`
+:   Kurzform von configuration (Konfiguration); Plural configs.
+
+`cwd`
+:   Current working directory (aktuelles Arbeitsverzeichnis).
+
+`deps`
+:   Kurzform von dependencies (Abhängigkeiten).
+
+`DMs`
+:   Direktnachrichten.
+
+`dotfile`
+:   Eine versteckte Konfigurationsdatei, deren Name mit einem Punkt beginnt.
+
+`env`
+:   Kurzform von environment (Umgebung) bzw. eine Umgebungsvariable.
+
+`gitignored`
+:   Per `.gitignore` von der Git-Verfolgung ausgeschlossen.
+
+`greppable`
+:   Leicht mit grep durchsuchbar.
+
+`Lc`
+:   Kurztoken, das zur Rechtschreibung akzeptiert wird; taucht in den Specs des Projekts auf.
+
+`lowercased`
+:   In Kleinschreibung umgewandelt.
+
+`PDFs`
+:   Dateien im Portable Document Format.
+
+`PNGs`
+:   Dateien im Portable Network Graphics-Format.
+
+`READMEs`
+:   Der Plural von README.
+
+`repo`
+:   Kurzform von repository; Plural repos.
+
+`skimmable`
+:   Leicht überfliegbar.
+
+`stderr`
+:   Standard-Fehlerausgabe (Standard error).
+
+`stdout`
+:   Standardausgabe (Standard output).
+
+`untracked`
+:   Nicht von der Versionsverwaltung erfasst.
+
+`untrusted`
+:   Ohne gewährtes Vertrauen.
+
+`unversioned`
+:   Nicht unter Versionsverwaltung bzw. ohne Version.
+
+`venv`
+:   Eine virtuelle Python-Umgebung.
+
+`virtualenv`
+:   Ein Python-Werkzeug für virtuelle Umgebungen bzw. eine solche Umgebung.
+
+### Beugungs- und Possessivformen
+
+Einige Einträge existieren nur, damit die Rechtschreibprüfung eine Beugungs- oder Possessivform akzeptiert, und tragen keine Bedeutung über ihr Grundwort hinaus: `commit's`, `criteria's`, `else's`, `maintainer's`, `README's` und `navigations`.
+
+## Vokabular `esphome`
+
+### Hardware-Bezeichner
+
+`ESP8285`
+:   Ein kompakter Controller-Chip mit eingebautem Flash, der in einigen Smart Plugs verwendet wird.
+
+`HLW8012`
+:   Ein Sensor-IC zur Leistungsmessung, der in Smart Plugs verwendet wird.
+
+`SP111`
+:   Ein ESPHome-kompatibles Smart-Plug-Modell.
+
+`NOUS`
+:   Eine Smart-Home-Hardware-Marke, z. B. der A1T-Stecker.
+
+`A1T`
+:   Ein Smart-Plug-Modell von NOUS.
+
+`Gosund`
+:   Eine Marke für Smart-Home-Geräte.
+
+### GPIO-Pins
+
+`GPIO`
+:   General-Purpose-Input/Output-Pin.
+
+`GPIO00`–`GPIO39`
+:   Nullgepolsterte zweistellige Pin-Namen, die die Regex `GPIO(0[0-9]|[1-3][0-9])` trifft und damit sowohl ESP8266- als auch ESP32-Pins abdeckt.
+
+### YAML-Konfigurationsschlüssel
+
+`baud_rate`
+:   Geschwindigkeit der seriellen Kommunikation.
+
+`status_led`
+:   Pin, der den Gerätestatus anzeigt.
+
+`restore_mode`
+:   Wie der Zustand eines Schalters nach dem Booten wiederhergestellt wird.
+
+`restore_from_flash`
+:   Ob der Zustand in den Flash geschrieben und daraus wiederhergestellt wird.
+
+`early_pin_init`
+:   Ob Pins früh im Boot-Vorgang initialisiert werden.
+
+`turn_on_action`
+:   Automation, die beim Einschalten einer Entität ausgeführt wird.
+
+`turn_off_action`
+:   Automation, die beim Ausschalten einer Entität ausgeführt wird.
+
+### Domänenbegriffe
+
+`automations`
+:   Regeln, die bei Ereignissen oder Bedingungen Aktionen auslösen.
+
+`Datetime`
+:   Ein kombinierter Datums- und Zeitwert bzw. -typ.
+
+`dBm`
+:   Dezibel-Milliwatt; eine Einheit der Signalstärke, z. B. WLAN-RSSI.
+
+`hostname`
+:   Der Netzwerkname eines Geräts; Plural hostnames.
+
+`LED`
+:   Light-Emitting Diode (Leuchtdiode); Plural LEDs.

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -1,0 +1,883 @@
+# Glossary
+
+Every term this package's vocabularies accept, defined. Entries are grouped into the same families as the [Vocabularies](vocabularies.md) page and shown by their readable lemma — the underlying `accept.txt` entry is often a regex that also covers plurals and other inflections (see [how matching works](vocabularies.md#how-entries-are-matched)). Brand and product names carry a short placement note rather than a full definition.
+
+## `technical` vocabulary
+
+### Tools, products, and brands
+
+`Ansible`
+:   Automation and configuration-management tool that needs no agent on managed hosts.
+
+`Anthropic`
+:   AI-safety company that builds the Claude models.
+
+`asdf`
+:   Version manager that handles multiple language runtimes through one CLI.
+
+`Astro`
+:   Web framework for content-driven sites that ships minimal client-side JavaScript.
+
+`Atlassian`
+:   Software vendor behind Jira, Confluence, and Bitbucket.
+
+`Bun`
+:   Fast all-in-one JavaScript runtime, bundler, and package manager.
+
+`chezmoi`
+:   Cross-machine dotfile manager.
+
+`Claude`
+:   Anthropic's family of large language models.
+
+`Contentful`
+:   API-first headless content-management system.
+
+`cookiecutter`
+:   Project-scaffolding tool that renders a template from a set of answers.
+
+`dayjs`
+:   Minimalist JavaScript date/time library.
+
+`Dependabot`
+:   GitHub bot that opens pull requests to update dependencies.
+
+`Deque`
+:   Accessibility-tooling company behind the axe testing engine.
+
+`DOMPurify`
+:   Client-side HTML sanitiser that strips XSS-prone markup.
+
+`Eleventy`
+:   Static-site generator, also written "11ty".
+
+`ESLint`
+:   Extensible linter for JavaScript and TypeScript.
+
+`ESPHome`
+:   Framework that builds firmware for ESP-based devices, commonly with Home Assistant.
+
+`Figma`
+:   Browser-based collaborative interface-design tool.
+
+`gh-plumbing`
+:   nolte's shared repository of reusable GitHub Actions workflows and Probot configurations.
+
+`godoc`
+:   Go's documentation generator.
+
+`Grammarly`
+:   Commercial writing assistant and grammar checker.
+
+`Graphviz`
+:   Graph-visualisation toolkit driven by the DOT language.
+
+`Inkbot`
+:   Third-party design studio/brand referenced in the project's asset specs.
+
+`Jira`
+:   Atlassian's issue- and project-tracking tool.
+
+`JUnit`
+:   Java unit-testing framework whose XML report format is a CI standard.
+
+`Mailchimp`
+:   Email-marketing and newsletter platform.
+
+`Mantine`
+:   React component and hooks library.
+
+`Midjourney`
+:   Generative-AI image service.
+
+`MkDocs`
+:   Static-site generator for project documentation, used here with the Material theme.
+
+`MUI`
+:   Material UI, a React component library implementing Material Design.
+
+`mypy`
+:   Static type checker for Python.
+
+`nginx`
+:   High-performance web server and reverse proxy.
+
+`nolte`
+:   The GitHub account that publishes this package.
+
+`notistack`
+:   React library for stacking snackbar notifications.
+
+`npm`
+:   Default package manager and registry for Node.js.
+
+`Numonic`
+:   Third-party brand referenced in the project's specs.
+
+`Probot`
+:   Framework for building GitHub Apps; backs the shared settings and labelling bots.
+
+`Pyright`
+:   Microsoft's static type checker for Python.
+
+`Recharts`
+:   React charting library built on D3.
+
+`Renovate`
+:   Automated dependency-update tool, configured here via a shared preset.
+
+`Shiki`
+:   Syntax highlighter that uses TextMate grammars and editor themes.
+
+`Skywork`
+:   Third-party AI model/service referenced in the project.
+
+`Supabase`
+:   Open-source backend platform built on PostgreSQL.
+
+`Tailwind`
+:   Utility-first CSS framework.
+
+`Taskfile`
+:   Configuration file for the go-task task runner (`task`).
+
+`Tauri`
+:   Framework for building desktop apps with a web frontend and a Rust core.
+
+`textstat`
+:   Python library that computes readability metrics.
+
+`Trivy`
+:   Open-source security and vulnerability scanner.
+
+`typedoc`
+:   Documentation generator for TypeScript.
+
+`Ulanzi`
+:   Consumer-hardware brand, e.g. the smart pixel-clock used in some configs.
+
+`Vercel`
+:   Hosting and deployment platform, originator of Next.js.
+
+`Vite`
+:   Fast frontend build tool and development server.
+
+`Vitest`
+:   Vite-native unit-testing framework.
+
+`vtracer`
+:   Tool that traces raster images into SVG vectors.
+
+`Vue`
+:   Progressive JavaScript framework for building user interfaces.
+
+`Webheads`
+:   Third-party brand/community referenced in the project.
+
+`Zod`
+:   TypeScript-first schema declaration and validation library.
+
+`zsh`
+:   The Z shell, an interactive Unix shell.
+
+### Software-engineering, CI/CD, security, and documentation terms
+
+`AC`
+:   Acceptance criterion — a condition a change must meet to count as done (plural ACs).
+
+`addon`
+:   A component that extends a host application.
+
+`ADR`
+:   Architecture Decision Record — a short note capturing one architectural choice and its rationale.
+
+`affordance`
+:   A design cue that signals how an element can be used.
+
+`agentic`
+:   Describing software, typically LLM-driven, that pursues goals autonomously.
+
+`agent`
+:   An autonomous program that performs tasks on a user's behalf.
+
+`allowlist`
+:   An explicit set of permitted entities; the inclusive counterpart to a denylist.
+
+`API`
+:   Application Programming Interface — a defined contract between software components.
+
+`async`
+:   Asynchronous — not blocking the caller while an operation completes.
+
+`attestable`
+:   Able to be cryptographically attested.
+
+`attestation`
+:   A signed claim about an artifact's origin or integrity, such as build provenance.
+
+`auditability`
+:   The degree to which a system's actions can be reviewed after the fact.
+
+`auditable`
+:   Able to be reviewed and checked against a record.
+
+`autofix`
+:   An automatically applied fix for a lint or build finding.
+
+`autofocus`
+:   HTML attribute that focuses an input when the page loads.
+
+`automerge`
+:   Merging a pull request automatically once all required checks pass.
+
+`backend`
+:   The server-side portion of an application.
+
+`backlink`
+:   A link pointing back to a page that references it.
+
+`bluetooth`
+:   Short-range wireless connectivity standard.
+
+`boolean`
+:   A value that is either true or false.
+
+`bundler`
+:   A tool that combines source modules into deployable bundles.
+
+`callout`
+:   A visually set-off note or admonition in documentation.
+
+`CI`
+:   Continuous Integration — automatically building and testing every change.
+
+`CLI`
+:   Command-Line Interface.
+
+`closeable`
+:   Able to be closed, e.g. a releasable resource.
+
+`conformant`
+:   Adhering to a specification or standard.
+
+`cron`
+:   Time-based job scheduler; also the syntax for its schedules.
+
+`CSP`
+:   Content Security Policy — an HTTP header constraining what a page may load.
+
+`CTA`
+:   Call To Action — a prompt urging the reader to take a step.
+
+`CVE`
+:   Common Vulnerabilities and Exposures — a public identifier for a security flaw.
+
+`debounce`
+:   To delay handling of rapid repeated events until they settle.
+
+`dedup`
+:   Short for deduplicate.
+
+`deduplicate`
+:   To remove duplicate entries.
+
+`denylist`
+:   An explicit set of blocked entities; the counterpart to an allowlist.
+
+`devcontainer`
+:   A container-defined, reproducible development environment.
+
+`diataxis`
+:   A documentation framework splitting docs into tutorials, how-tos, reference, and explanation.
+
+`dialog`
+:   A modal or non-modal window prompting for input or confirmation.
+
+`diffable`
+:   Able to be compared line-by-line as a diff.
+
+`Dockerfile`
+:   A text recipe describing how to build a container image.
+
+`docstring`
+:   An inline documentation string embedded in source code.
+
+`enum`
+:   Enumeration — a type with a fixed set of named values.
+
+`favicon`
+:   The small icon a browser shows for a site.
+
+`focusable`
+:   Able to receive keyboard focus.
+
+`formatter`
+:   A tool that rewrites code to a consistent style.
+
+`frontend`
+:   The client-side, user-facing part of an application.
+
+`frontmatter`
+:   The metadata block, often YAML, at the top of a Markdown file.
+
+`geoblocking`
+:   Restricting access to content by geographic region.
+
+`gerund`
+:   A verb's `-ing` form used as a noun.
+
+`GHSA`
+:   GitHub Security Advisory identifier.
+
+`Guillemets`
+:   Angle-shaped quotation marks (« »).
+
+`HMAC`
+:   Hash-based Message Authentication Code — a keyed integrity and authenticity check.
+
+`hoc`
+:   Higher-Order Component — a React function that wraps a component to add behaviour.
+
+`hotfix`
+:   An urgent fix applied directly to a released version.
+
+`idempotency`
+:   The property that repeating an operation yields the same result as doing it once.
+
+`idempotently`
+:   In an idempotent manner.
+
+`implementor`
+:   One who implements a specification, also spelled "implementer".
+
+`inlining`
+:   Substituting a definition directly at its use site.
+
+`inspectable`
+:   Able to be examined at runtime or via tooling.
+
+`lede`
+:   The opening of an article that states its core point; plural ledes.
+
+`lockfile`
+:   A file pinning exact resolved dependency versions.
+
+`lookup`
+:   A retrieval of a value by key.
+
+`lossy`
+:   Discarding some information, as in lossy compression.
+
+`memoise`
+:   To cache a function's result for repeated identical inputs.
+
+`mergeable`
+:   Able to be merged without conflict.
+
+`misclassification`
+:   Assigning something to the wrong category.
+
+`mitigation`
+:   A measure that reduces a risk's likelihood or impact.
+
+`monorepo`
+:   A single repository holding many projects.
+
+`MR`
+:   Merge Request — GitLab's term for a pull request.
+
+`MUSTs` / `SHOULDs`
+:   Pluralised RFC 2119 requirement keywords.
+
+`Newswire`
+:   A service that distributes news copy to outlets.
+
+`NFR`
+:   Non-Functional Requirement — a quality constraint such as performance or security.
+
+`OAuth`
+:   Open standard for delegated authorization.
+
+`OQ`
+:   Open Question — an unresolved point recorded in a spec.
+
+`parseable`
+:   Able to be parsed.
+
+`postcondition`
+:   A condition guaranteed to hold after an operation.
+
+`preload`
+:   To fetch a resource ahead of when it is needed.
+
+`PR`
+:   Pull Request — a proposed change submitted for review and merge.
+
+`px`
+:   CSS pixel unit.
+
+`PYSEC`
+:   Identifier for a Python-ecosystem security advisory.
+
+`queryable`
+:   Able to be queried.
+
+`querystring`
+:   The `key=value` portion of a URL after `?`.
+
+`reachability`
+:   Whether a node or state can be reached from another.
+
+`rebase`
+:   To replay commits onto a new base; also rebases, rebasing.
+
+`reflog`
+:   A log of where Git references have pointed (`git reflog`).
+
+`reusable`
+:   Able to be used again in another context.
+
+`runbook`
+:   A documented procedure for operating or recovering a system.
+
+`runtime`
+:   The environment in which a program executes; plural runtimes.
+
+`sandboxing`
+:   Isolating code so it cannot affect the host beyond a permitted boundary.
+
+`scannability`
+:   How easily text can be skimmed by eye.
+
+`SemVer`
+:   Semantic Versioning — the `MAJOR.MINOR.PATCH` version scheme.
+
+`severity`
+:   The graded impact level of a finding or incident; plural severities.
+
+`SHA`
+:   Secure Hash Algorithm; commonly a Git commit hash.
+
+`SLA`
+:   Service-Level Agreement.
+
+`snackbar`
+:   A brief, non-blocking notification shown at a screen edge.
+
+`sref`
+:   Midjourney's style-reference parameter (`--sref`).
+
+`SRE`
+:   Site Reliability Engineering, or a Site Reliability Engineer.
+
+`Subresource`
+:   A resource a page loads in addition to itself, as in Subresource Integrity.
+
+`stylers`
+:   Components or tools that apply visual styling.
+
+`symbolication`
+:   Mapping memory addresses in a crash back to source symbols.
+
+`teardown`
+:   Cleanup run after a test or process.
+
+`thresholding`
+:   Applying a cut-off value to classify or filter.
+
+`tooltip`
+:   A small hint shown on hover or focus.
+
+`typecheck`
+:   To verify a program against its type rules.
+
+`unparseable`
+:   Not able to be parsed.
+
+`validator`
+:   A component that checks input against rules.
+
+`viewport`
+:   The visible region of a page in the browser.
+
+`wordmark`
+:   A logo rendered as styled text.
+
+`worktree`
+:   A linked working directory of a Git repository.
+
+`YAML`
+:   YAML Ain't Markup Language — a human-readable data-serialisation format.
+
+### Naming, lifecycle, and workflow words
+
+`achievability`
+:   Whether a goal is realistically attainable — the "A" in SMART.
+
+`autoallow`
+:   To permit automatically without manual approval.
+
+`autodetect`
+:   To detect automatically without explicit configuration.
+
+`autolink`
+:   To turn a reference into a hyperlink automatically.
+
+`autoload`
+:   To load automatically on demand.
+
+`automatable`
+:   Able to be automated.
+
+`auto-tag`
+:   To apply a tag automatically.
+
+`bikeshedding`
+:   Spending disproportionate effort on trivial details.
+
+`browsable`
+:   Able to be browsed.
+
+`bypassable`
+:   Able to be bypassed.
+
+`definitionally`
+:   By definition.
+
+`disambiguation`
+:   Resolving which of several meanings is intended.
+
+`discoverability`
+:   How easily something can be found.
+
+`dispatchable`
+:   Able to be dispatched, i.e. routed to a handler.
+
+`dogfood`
+:   To use one's own product internally; dogfooding.
+
+`favouriting`
+:   Marking an item as a favourite.
+
+`invocable`
+:   Able to be invoked, also "invokable".
+
+`kebab`
+:   As in kebab-case — lowercase words joined by hyphens.
+
+`linkability`
+:   How readily items can be linked to one another.
+
+`mandatoriness`
+:   The degree to which something is mandatory.
+
+`namespace`
+:   A named scope that keeps identifiers distinct; namespaced.
+
+`onboarding`
+:   Bringing a new user, contributor, or repository up to speed.
+
+`operationalize`
+:   To turn a concept into a concrete, runnable procedure.
+
+`overridable`
+:   Able to be overridden.
+
+`rebalancing`
+:   Redistributing load or allocation.
+
+`recalibrated`
+:   Adjusted back to a correct reference.
+
+`rephrase`
+:   To express again in different words.
+
+`repointing`
+:   Redirecting a reference to a new target.
+
+`repurpose`
+:   To adapt something for a new use.
+
+`retarget`
+:   To change the intended target.
+
+`retconning`
+:   Retroactively changing established facts.
+
+`reviewability`
+:   How readily a change can be reviewed.
+
+`revisitable`
+:   Able to be revisited.
+
+`roadmap`
+:   A planned sequence of future work; plural roadmaps.
+
+`rollout`
+:   The staged release of a change.
+
+`routable`
+:   Able to be routed to a destination.
+
+`scaffold`
+:   To generate a starting skeleton of files; scaffolding.
+
+`slugification`
+:   Converting a string into a URL-safe slug.
+
+`subagent`
+:   An agent dispatched by another agent.
+
+`subfolder`
+:   A nested folder.
+
+`submodule`
+:   A repository embedded within another (a Git submodule).
+
+`subproject`
+:   A project nested within a larger one.
+
+`subroot`
+:   A nested root directory within a tree.
+
+`subtask`
+:   A task that is part of a larger one.
+
+`toolchain`
+:   The set of tools used to build and ship software.
+
+`triage`
+:   To sort items by priority; triaged, triaging, triages.
+
+`triggerer`
+:   The actor or event that triggers something.
+
+`underperforming`
+:   Performing below expectation.
+
+`unreviewed`
+:   Not yet reviewed.
+
+`untriaged`
+:   Not yet triaged.
+
+`upgrader`
+:   A tool or actor that performs upgrades.
+
+`upstreamed`
+:   Contributed back to the upstream source.
+
+`vectorise`
+:   To convert to a vector representation.
+
+`vendor`
+:   To copy a dependency's source into the repository; vendored, vendoring.
+
+`virtualise`
+:   To create a virtual version of something.
+
+`prepended`
+:   Added to the beginning.
+
+### Proper names — writing, readability, and accessibility sources
+
+These surnames are accepted because they appear as cited authors or sources in the project's readability, editorial-style, and accessibility specs; the three colour-vision terms come from the accessibility domain.
+
+`Bamberger`
+:   Co-originator, with Vanecek, of German-language readability research.
+
+`Carliner`
+:   Saul Carliner, a technical-communication author.
+
+`Chissom`
+:   Co-author of the Flesch–Kincaid grade-level study.
+
+`Desrosiers`
+:   Surname cited as a source in the readability/writing specs.
+
+`Fishburne`
+:   Co-author of the Flesch–Kincaid grade-level study.
+
+`Flesch`
+:   Rudolf Flesch, originator of the Flesch Reading Ease score.
+
+`Kalzumeus`
+:   The blog and handle of software writer Patrick McKenzie.
+
+`Kincaid`
+:   J. P. Kincaid, co-creator of the Flesch–Kincaid readability metric.
+
+`Kissane`
+:   Erin Kissane, a content-strategy author.
+
+`Lannon`
+:   John Lannon, a technical-writing textbook author.
+
+`Matuschak`
+:   Andy Matuschak, known for work on notes and knowledge tools.
+
+`Stockton`
+:   Surname cited as a source in the writing/readability specs.
+
+`Strunk`
+:   William Strunk Jr., co-author of "The Elements of Style".
+
+`Vanecek`
+:   Co-originator, with Bamberger, of German-language readability research.
+
+`Zinsser`
+:   William Zinsser, author of "On Writing Well".
+
+`deutan`
+:   Colour-vision deficiency affecting green perception (the deuteranopia family).
+
+`protan`
+:   Colour-vision deficiency affecting red perception (the protanopia family).
+
+`tritan`
+:   Colour-vision deficiency affecting blue perception (the tritanopia family).
+
+### Shell and runtime shorthands
+
+`basename`
+:   The final component of a file path.
+
+`config`
+:   Short for configuration; plural configs.
+
+`cwd`
+:   Current working directory.
+
+`deps`
+:   Short for dependencies.
+
+`DMs`
+:   Direct messages.
+
+`dotfile`
+:   A hidden configuration file whose name begins with a dot.
+
+`env`
+:   Short for environment, or an environment variable.
+
+`gitignored`
+:   Excluded from Git tracking via `.gitignore`.
+
+`greppable`
+:   Easy to search with grep.
+
+`Lc`
+:   Short token accepted for spelling; appears in the project's specs.
+
+`lowercased`
+:   Converted to lowercase.
+
+`PDFs`
+:   Portable Document Format files.
+
+`PNGs`
+:   Portable Network Graphics files.
+
+`READMEs`
+:   The plural of README.
+
+`repo`
+:   Short for repository; plural repos.
+
+`skimmable`
+:   Easy to skim.
+
+`stderr`
+:   Standard error stream.
+
+`stdout`
+:   Standard output stream.
+
+`untracked`
+:   Not tracked by version control.
+
+`untrusted`
+:   Not granted trust.
+
+`unversioned`
+:   Not under version control, or lacking a version.
+
+`venv`
+:   A Python virtual environment.
+
+`virtualenv`
+:   A Python virtual-environment tool or environment.
+
+### Inflected and possessive forms
+
+A few entries exist only so the spell-checker accepts an inflected or possessive form and carry no meaning beyond their base word: `commit's`, `criteria's`, `else's`, `maintainer's`, `README's`, and `navigations`.
+
+## `esphome` vocabulary
+
+### Hardware identifiers
+
+`ESP8285`
+:   A compact controller chip with built-in flash, used in some smart plugs.
+
+`HLW8012`
+:   A power-metering sensor IC used in smart plugs.
+
+`SP111`
+:   An ESPHome-compatible smart-plug model.
+
+`NOUS`
+:   A smart-home hardware brand, e.g. the A1T plug.
+
+`A1T`
+:   A NOUS smart-plug model.
+
+`Gosund`
+:   A smart-home device brand.
+
+### GPIO pins
+
+`GPIO`
+:   General-Purpose Input/Output pin.
+
+`GPIO00`–`GPIO39`
+:   Zero-padded two-digit pin names matched by the regex `GPIO(0[0-9]|[1-3][0-9])`, covering both ESP8266 and ESP32 pins.
+
+### YAML configuration keys
+
+`baud_rate`
+:   Serial communication speed.
+
+`status_led`
+:   Pin configured to show device status.
+
+`restore_mode`
+:   How a switch's state is restored after boot.
+
+`restore_from_flash`
+:   Whether state is persisted to and restored from flash.
+
+`early_pin_init`
+:   Whether pins are initialised early during boot.
+
+`turn_on_action`
+:   Automation run when an entity turns on.
+
+`turn_off_action`
+:   Automation run when an entity turns off.
+
+### Domain words
+
+`automations`
+:   Rules that trigger actions on events or conditions.
+
+`Datetime`
+:   A combined date-and-time value or type.
+
+`dBm`
+:   Decibel-milliwatts; a signal-strength unit, e.g. Wi-Fi RSSI.
+
+`hostname`
+:   A device's network name; plural hostnames.
+
+`LED`
+:   Light-Emitting Diode; plural LEDs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
 nav:
   - Overview: index.md
   - Vocabularies: vocabularies.md
+  - Glossary: glossary.md
   - Contributing: contributing.md
   - Specifications: specifications.md
 
@@ -66,12 +67,14 @@ plugins:
           nav_translations:
             Overview: Überblick
             Vocabularies: Vokabulare
+            Glossary: Glossar
             Contributing: Mitwirken
             Specifications: Spezifikationen
 
 markdown_extensions:
   - admonition
   - attr_list
+  - def_list
   - md_in_html
   - tables
   - toc:


### PR DESCRIPTION
## Summary

Add a bilingual (English + German) Glossary page that defines every entry in the `technical` and `esphome` accept.txt vocabularies, so readers can look up what each accepted term means rather than inferring it from the vocabulary list.

## Changes

- Add `docs/en/glossary.md` and `docs/de/glossary.md`: all 296 vocabulary entries, grouped into the same families as the Vocabularies page and rendered as definition lists keyed by each term's readable lemma.
- Classify by type: explanatory terms get a real definition, brand/product names get a short placement note, and trivial possessive forms are collapsed into one grouped line.
- `mkdocs.yml`: add the Glossary nav entry plus its `Glossar` `nav_translation`, and enable the `def_list` markdown extension.
- Word the English definitions so the page passes Vale without expanding the shipped vocabulary — the release artifact (`accept.txt`) is untouched.

## Linked issues

None

## Testing

- `mkdocs build --strict` — clean; both language trees build, 284 definition terms each, Glossary nav label translated to `Glossar`.
- Coverage check — every `technical` and `esphome` accept.txt entry is present (0 gaps).
- `vale .` — 0 errors across 24 files.
- `task --yes lint` / pre-commit — pass.

## Risk / rollout notes

Docs-only; the release zip (`nolte-styles.zip`) and the vocabularies are unaffected. The new page ships on the next `release-cd-deliver-docs.yml` publish. Adding a few of the terms surfaced while writing (e.g. `ESP8266`, `microcontroller`, US spelling variants) to the `technical` vocabulary would be a separate, deliberate vocab PR — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)