### PR TITLE
docs(glossary): editorial pass — fix quotes and tighten phrasings

### DIFF
--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -49,7 +49,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Clientseitiger HTML-Sanitizer, der XSS-anfälliges Markup entfernt.
 
 `Eleventy`
-:   Static-Site-Generator, auch „11ty" geschrieben.
+:   Static-Site-Generator, auch „11ty“ geschrieben.
 
 `ESLint`
 :   Erweiterbarer Linter für JavaScript und TypeScript.
@@ -73,7 +73,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Toolkit zur Graph-Visualisierung, gesteuert über die Sprache DOT.
 
 `Inkbot`
-:   Drittanbieter-Designstudio bzw. -marke, auf die in den Asset-Specs verwiesen wird.
+:   Drittanbieter-Designstudio, auf das in den Specs des Projekts verwiesen wird.
 
 `Jira`
 :   Atlassians Werkzeug zur Vorgangs- und Projektverfolgung.
@@ -130,7 +130,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Syntax-Highlighter, der TextMate-Grammatiken und Editor-Themes nutzt.
 
 `Skywork`
-:   Drittanbieter-KI-Modell bzw. -Dienst, auf den im Projekt verwiesen wird.
+:   Drittanbieter-KI-Dienst, auf den in den Specs des Projekts verwiesen wird.
 
 `Supabase`
 :   Quelloffene Backend-Plattform auf Basis von PostgreSQL.
@@ -172,7 +172,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Progressives JavaScript-Framework zum Bau von Benutzeroberflächen.
 
 `Webheads`
-:   Drittanbieter-Marke bzw. -Community, auf die im Projekt verwiesen wird.
+:   Drittanbieter-Marke, auf die in den Specs des Projekts verwiesen wird.
 
 `Zod`
 :   TypeScript-first-Bibliothek zur Schema-Deklaration und -Validierung.
@@ -255,7 +255,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Command-Line Interface (Kommandozeilen-Schnittstelle).
 
 `closeable`
-:   Schließbar, etwa eine freigebbare Ressource.
+:   Schließbar — von einer Ressource, die freigegeben werden muss.
 
 `conformant`
 :   Einer Spezifikation oder einem Standard entsprechend.
@@ -348,7 +348,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Auf idempotente Weise.
 
 `implementor`
-:   Wer eine Spezifikation umsetzt, auch „implementer" geschrieben.
+:   Wer eine Spezifikation umsetzt, auch „implementer“ geschrieben.
 
 `inlining`
 :   Eine Definition direkt an ihrer Verwendungsstelle einsetzen.
@@ -512,7 +512,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 ### Begriffe zu Benennung, Lebenszyklus und Workflow
 
 `achievability`
-:   Ob ein Ziel realistisch erreichbar ist — das „A" in SMART.
+:   Ob ein Ziel realistisch erreichbar ist — das „A“ in SMART.
 
 `autoallow`
 :   Etwas automatisch erlauben, ohne manuelle Freigabe.
@@ -542,7 +542,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Umgehbar.
 
 `definitionally`
-:   Per Definition.
+:   Der Definition nach.
 
 `disambiguation`
 :   Das Auflösen, welche von mehreren Bedeutungen gemeint ist.
@@ -560,7 +560,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Das Markieren eines Elements als Favorit.
 
 `invocable`
-:   Aufrufbar, auch „invokable".
+:   Aufrufbar, auch „invokable“.
 
 `kebab`
 :   Wie in kebab-case — kleingeschriebene, durch Bindestriche verbundene Wörter.
@@ -720,13 +720,13 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 :   Nachname, der als Quelle in den Specs zu Schreiben/Lesbarkeit zitiert wird.
 
 `Strunk`
-:   William Strunk Jr., Mitautor von „The Elements of Style".
+:   William Strunk Jr., Mitautor von „The Elements of Style“.
 
 `Vanecek`
 :   Mitbegründer der deutschsprachigen Lesbarkeitsforschung, gemeinsam mit Bamberger.
 
 `Zinsser`
-:   William Zinsser, Autor von „On Writing Well".
+:   William Zinsser, Autor von „On Writing Well“.
 
 `deutan`
 :   Farbsehschwäche, die die Grünwahrnehmung betrifft (Deuteranopie-Familie).

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -73,7 +73,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Graph-visualisation toolkit driven by the DOT language.
 
 `Inkbot`
-:   Third-party design studio/brand referenced in the project's asset specs.
+:   Third-party design studio referenced in the project's specs.
 
 `Jira`
 :   Atlassian's issue- and project-tracking tool.
@@ -130,7 +130,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Syntax highlighter that uses TextMate grammars and editor themes.
 
 `Skywork`
-:   Third-party AI model/service referenced in the project.
+:   Third-party AI service referenced in the project's specs.
 
 `Supabase`
 :   Open-source backend platform built on PostgreSQL.
@@ -172,7 +172,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Progressive JavaScript framework for building user interfaces.
 
 `Webheads`
-:   Third-party brand/community referenced in the project.
+:   Third-party brand referenced in the project's specs.
 
 `Zod`
 :   TypeScript-first schema declaration and validation library.
@@ -255,7 +255,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Command-Line Interface.
 
 `closeable`
-:   Able to be closed, e.g. a releasable resource.
+:   Able to be closed — said of a resource that must be released.
 
 `conformant`
 :   Adhering to a specification or standard.


### PR DESCRIPTION
## Summary

Editorial review of the bilingual glossary added in the previous release: fix mixed quotation marks in the German page and tighten a few phrasings in both languages. Content-only — no glossary entries are added or removed.

## Changes

- Fix six mixed quotation marks in `docs/de/glossary.md` (German opening `„` paired with a straight closing `"` → `„…"`): `11ty`, `implementer`, the `A` in SMART, `invokable`, "The Elements of Style", "On Writing Well".
- Replace the colloquial "Per Definition." with "Der Definition nach." (`definitionally`).
- Unify the four generic brand notes (Inkbot, Numonic, Skywork, Webheads) onto one phrasing in both languages.
- Reword the vague "releasable resource" / "freigebbare Ressource" in the `closeable` definition for clarity.

## Linked issues

None

## Testing

- `mkdocs build --strict` — clean; both language trees build.
- LanguageTool re-check on `docs/de/` — no mixed-quote or "Per Definition" findings remain (residual hits are false positives on English technical terms).
- `vale .` — 0 errors across 24 files.
- `task --yes lint` / pre-commit — pass.

## Risk / rollout notes

Docs-only; the release zip (`nolte-styles.zip`) and the vocabularies are unaffected. Ships on the next `release-cd-deliver-docs.yml` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)