### PR TITLE
docs(glossary): cover and copy-edit the entries added in #24

### DIFF
--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -339,7 +339,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Command-Line Interface (Kommandozeilen-Schnittstelle).
 
 `clickability`
-:   Wie deutlich ein Element zum Klicken einlädt und ihn erfasst.
+:   Wie leicht erkennbar und anklickbar ein Element ist.
 
 `closeable`
 :   Schließbar — von einer Ressource, die freigegeben werden muss.
@@ -372,7 +372,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 :   Schnelle, wiederholte Ereignisse erst behandeln, wenn sie sich beruhigt haben.
 
 `decompounding`
-:   Das Zerlegen eines zusammengesetzten Wortes in seine Bestandteile, in der deutschen Textverarbeitung üblich; ein Decompounder leistet dies.
+:   Das Zerlegen eines zusammengesetzten Wortes in seine Bestandteile, in der deutschen Textverarbeitung üblich; die zuständige Komponente ist ein Decompounder.
 
 `dedup`
 :   Kurzform von deduplicate.

--- a/docs/de/glossary.md
+++ b/docs/de/glossary.md
@@ -30,8 +30,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Claude`
 :   Anthropics Familie großer Sprachmodelle.
 
+`Cloudflare`
+:   Anbieter von Edge-Netzwerk, CDN und Sicherheitsdiensten.
+
 `Contentful`
 :   API-first Headless-Content-Management-System.
+
+`ControlNet`
+:   Eine Netzwerk-Erweiterung, die die Bildgenerierung an Vorgaben wie Kanten oder Pose koppelt.
 
 `cookiecutter`
 :   Scaffolding-Werkzeug, das aus Antworten eine Projektvorlage rendert.
@@ -44,6 +50,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `Deque`
 :   Unternehmen für Accessibility-Werkzeuge, Urheber der axe-Engine.
+
+`Docusaurus`
+:   Ein React-basierter Static-Site-Generator für Dokumentation.
 
 `DOMPurify`
 :   Clientseitiger HTML-Sanitizer, der XSS-anfälliges Markup entfernt.
@@ -60,6 +69,15 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Figma`
 :   Browserbasiertes, kollaboratives Werkzeug für Interface-Design.
 
+`FLUX`
+:   Eine Familie von Text-zu-Bild-Modellen von Black Forest Labs.
+
+`Gemini`
+:   Googles Familie multimodaler großer Sprachmodelle.
+
+`Gemma`
+:   Googles Familie von Sprachmodellen mit offenen Gewichten.
+
 `gh-plumbing`
 :   noltes geteiltes Repository mit wiederverwendbaren GitHub-Actions-Workflows und Probot-Konfigurationen.
 
@@ -72,6 +90,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Graphviz`
 :   Toolkit zur Graph-Visualisierung, gesteuert über die Sprache DOT.
 
+`Imagen`
+:   Googles Text-zu-Bild-Modell.
+
 `Inkbot`
 :   Drittanbieter-Designstudio, auf das in den Specs des Projekts verwiesen wird.
 
@@ -80,6 +101,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `JUnit`
 :   Java-Unit-Test-Framework, dessen XML-Reportformat ein CI-Standard ist.
+
+`kamerplanter`
+:   Ein nolte-Projekt (ein Zimmerpflanzen-Pflegehelfer).
 
 `Mailchimp`
 :   Plattform für E-Mail-Marketing und Newsletter.
@@ -93,11 +117,20 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `MkDocs`
 :   Static-Site-Generator für Projektdokumentation, hier mit dem Material-Theme genutzt.
 
+`Mockito`
+:   Ein Mocking-Framework für Java-Unit-Tests.
+
 `MUI`
 :   Material UI, eine React-Komponentenbibliothek, die Material Design umsetzt.
 
+`mutmut`
+:   Ein Mutation-Testing-Werkzeug für Python.
+
 `mypy`
 :   Statischer Typprüfer für Python.
+
+`Netlify`
+:   Eine Hosting- und Deployment-Plattform für Web-Frontends.
 
 `nginx`
 :   Performanter Webserver und Reverse Proxy.
@@ -114,11 +147,20 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Numonic`
 :   Drittanbieter-Marke, auf die in den Specs des Projekts verwiesen wird.
 
+`pitest`
+:   Ein Mutation-Testing-Framework für Java (PIT).
+
+`Pollinations`
+:   Eine offene API für generative KI-Medien.
+
 `Probot`
 :   Framework zum Bau von GitHub Apps; trägt die geteilten Settings- und Labelling-Bots.
 
 `Pyright`
 :   Microsofts statischer Typprüfer für Python.
+
+`pytest`
+:   Das De-facto-Test-Framework für Python.
 
 `Recharts`
 :   React-Charting-Bibliothek auf Basis von D3.
@@ -126,14 +168,29 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Renovate`
 :   Werkzeug zur automatisierten Aktualisierung von Abhängigkeiten, hier über ein geteiltes Preset konfiguriert.
 
+`SDXL`
+:   Stable Diffusion XL, ein Text-zu-Bild-Modell.
+
 `Shiki`
 :   Syntax-Highlighter, der TextMate-Grammatiken und Editor-Themes nutzt.
+
+`Sinon`
+:   Eine JavaScript-Bibliothek für Test-Spies, -Stubs und -Mocks.
 
 `Skywork`
 :   Drittanbieter-KI-Dienst, auf den in den Specs des Projekts verwiesen wird.
 
+`Spotify`
+:   Der Musik-Streaming-Dienst.
+
+`Stryker`
+:   Ein Mutation-Testing-Framework für JavaScript, C# und Scala.
+
 `Supabase`
 :   Quelloffene Backend-Plattform auf Basis von PostgreSQL.
+
+`Syft`
+:   Ein Werkzeug, das eine Software-Stückliste (SBOM) aus Images und Dateisystemen erzeugt.
 
 `Tailwind`
 :   Utility-first-CSS-Framework.
@@ -144,8 +201,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Tauri`
 :   Framework zum Bau von Desktop-Apps mit Web-Frontend und Rust-Kern.
 
+`Testcontainers`
+:   Eine Bibliothek, die Wegwerf-Docker-Container für Integrationstests bereitstellt.
+
 `textstat`
 :   Python-Bibliothek, die Lesbarkeitsmetriken berechnet.
+
+`Thoughtworks`
+:   Eine Software-Beratung, bekannt für das Technology Radar.
 
 `Trivy`
 :   Quelloffener Security- und Schwachstellen-Scanner.
@@ -171,8 +234,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `Vue`
 :   Progressives JavaScript-Framework zum Bau von Benutzeroberflächen.
 
+`Wayback`
+:   Wie in Wayback Machine, dem Web-Snapshot-Dienst des Internet Archive.
+
 `Webheads`
 :   Drittanbieter-Marke, auf die in den Specs des Projekts verwiesen wird.
+
+`Zlib`
+:   Eine verlustfreie Datenkompressionsbibliothek; auch der Name ihrer permissiven Lizenz.
 
 `Zod`
 :   TypeScript-first-Bibliothek zur Schema-Deklaration und -Validierung.
@@ -202,6 +271,12 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `allowlist`
 :   Eine explizite Menge erlaubter Einheiten; das einschließende Gegenstück zur Denylist.
+
+`alphanumerics`
+:   Zeichen, die Buchstaben oder Ziffern sind.
+
+`anonymisation`
+:   Das irreversible Entfernen personenbezogener Daten, sodass Personen nicht mehr identifizierbar sind.
 
 `API`
 :   Application Programming Interface — ein definierter Vertrag zwischen Softwarekomponenten.
@@ -236,6 +311,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `backlink`
 :   Ein Link, der auf eine verweisende Seite zurückzeigt.
 
+`backoff`
+:   Das schrittweise Erhöhen der Wartezeit zwischen Wiederholungen.
+
 `bluetooth`
 :   Standard für drahtlose Verbindung über kurze Distanz.
 
@@ -248,17 +326,32 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `callout`
 :   Ein optisch hervorgehobener Hinweis bzw. eine Admonition in der Dokumentation.
 
+`CDN`
+:   Content Delivery Network — geografisch verteilte Server, die Inhalte nutzernah zwischenspeichern und ausliefern.
+
+`charset`
+:   Zeichensatz — die Kodierung, die Bytes auf Zeichen abbildet.
+
 `CI`
 :   Continuous Integration — das automatische Bauen und Testen jeder Änderung.
 
 `CLI`
 :   Command-Line Interface (Kommandozeilen-Schnittstelle).
 
+`clickability`
+:   Wie deutlich ein Element zum Klicken einlädt und ihn erfasst.
+
 `closeable`
 :   Schließbar — von einer Ressource, die freigegeben werden muss.
 
+`colocated`
+:   Am selben Ort abgelegt, z. B. eine Testdatei neben dem getesteten Code.
+
 `conformant`
 :   Einer Spezifikation oder einem Standard entsprechend.
+
+`copyrightability`
+:   Ob ein Werk urheberrechtlich schützbar ist.
 
 `cron`
 :   Zeitbasierter Job-Scheduler; auch die Syntax seiner Zeitpläne.
@@ -272,8 +365,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `CVE`
 :   Common Vulnerabilities and Exposures — eine öffentliche Kennung für eine Sicherheitslücke.
 
+`datastore`
+:   Ein System, das Daten persistiert (Datenbank, Key-Value-Store, Objektspeicher).
+
 `debounce`
 :   Schnelle, wiederholte Ereignisse erst behandeln, wenn sie sich beruhigt haben.
+
+`decompounding`
+:   Das Zerlegen eines zusammengesetzten Wortes in seine Bestandteile, in der deutschen Textverarbeitung üblich; ein Decompounder leistet dies.
 
 `dedup`
 :   Kurzform von deduplicate.
@@ -283,6 +382,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `denylist`
 :   Eine explizite Menge blockierter Einheiten; Gegenstück zur Allowlist.
+
+`deserialise`
+:   Ein In-Memory-Objekt aus einer serialisierten Form rekonstruieren; der Vorgang ist die Deserialisierung.
 
 `devcontainer`
 :   Eine per Container definierte, reproduzierbare Entwicklungsumgebung.
@@ -302,8 +404,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `docstring`
 :   Ein in den Quellcode eingebetteter Dokumentationsstring.
 
+`DTOs`
+:   Data Transfer Objects — einfache Strukturen, die Daten über Grenzen transportieren.
+
 `enum`
 :   Aufzählung — ein Typ mit einer festen Menge benannter Werte.
+
+`ePrivacy`
+:   Die EU-ePrivacy-Richtlinie, die elektronische Kommunikation und Cookies regelt.
 
 `favicon`
 :   Das kleine Icon, das ein Browser für eine Seite anzeigt.
@@ -320,6 +428,12 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `frontmatter`
 :   Der Metadatenblock, oft YAML, am Anfang einer Markdown-Datei.
 
+`Gedankenstrich`
+:   Der Gedankenstrich, als Einschub- oder Bis-Strich verwendet.
+
+`generativelanguage`
+:   Das Host-Segment von Googles Generative Language API (`generativelanguage.googleapis.com`).
+
 `geoblocking`
 :   Das Beschränken des Zugriffs auf Inhalte nach geografischer Region.
 
@@ -329,8 +443,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `GHSA`
 :   Kennung eines GitHub Security Advisory.
 
+`Goodhart`
+:   Wie in Goodharts Gesetz: Wird ein Maß zum Ziel, taugt es nicht mehr als gutes Maß.
+
 `Guillemets`
 :   Winkelförmige Anführungszeichen (« »).
+
+`hardcoded`
+:   Als fester Literalwert im Code geschrieben statt konfiguriert.
 
 `HMAC`
 :   Hash-based Message Authentication Code — eine schlüsselbasierte Integritäts- und Echtheitsprüfung.
@@ -356,14 +476,32 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `inspectable`
 :   Zur Laufzeit oder per Werkzeug untersuchbar.
 
+`Komposita`
+:   Zusammengesetzte Wörter, etwa in der Lesbarkeitsanalyse.
+
+`latents`
+:   Die komprimierten Latent-Space-Repräsentationen, in denen ein generatives Modell arbeitet.
+
 `lede`
 :   Der Einstieg eines Artikels, der dessen Kernaussage nennt; Plural ledes.
+
+`lektorat`
+:   Eine redaktionelle Durchsicht und Überarbeitung von Prosa.
+
+`liveness`
+:   Ob ein laufender Prozess gesund genug ist, um weiter zu bedienen, wie bei einer Liveness-Probe.
+
+`LIX`
+:   Ein Lesbarkeitsindex auf Basis von Wort- und Satzlänge.
 
 `lockfile`
 :   Eine Datei, die exakt aufgelöste Abhängigkeitsversionen festschreibt.
 
 `lookup`
 :   Das Abrufen eines Werts über einen Schlüssel.
+
+`LoRA`
+:   Low-Rank Adaptation — eine effiziente Feinabstimmungsmethode für große Modelle.
 
 `lossy`
 :   Information verwerfend, wie bei verlustbehafteter Kompression.
@@ -380,20 +518,32 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `mitigation`
 :   Eine Maßnahme, die Wahrscheinlichkeit oder Auswirkung eines Risikos senkt.
 
+`mockist`
+:   Ein Teststil, der Mocks bevorzugt, um die getestete Einheit zu isolieren, im Gegensatz zum klassizistischen Stil.
+
 `monorepo`
 :   Ein einzelnes Repository, das viele Projekte enthält.
 
 `MR`
 :   Merge Request — GitLabs Bezeichnung für einen Pull Request.
 
+`multimodal`
+:   Mehr als eine Ein- oder Ausgabemodalität verarbeitend, etwa Text und Bilder.
+
 `MUSTs` / `SHOULDs`
 :   Pluralisierte RFC-2119-Anforderungsschlüsselwörter.
+
+`nano`
+:   Die kleinste Variante einer Modellfamilie, z. B. Gemini Nano.
 
 `Newswire`
 :   Ein Dienst, der Nachrichtenmeldungen an Redaktionen verteilt.
 
 `NFR`
 :   Non-Functional Requirement — eine Qualitätsanforderung wie Performance oder Security.
+
+`nominalisation`
+:   Das Umwandeln eines Verbs oder Adjektivs in ein Substantiv, oft ein Lesbarkeitsproblem.
 
 `OAuth`
 :   Offener Standard für delegierte Autorisierung.
@@ -404,6 +554,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `parseable`
 :   Parsebar.
 
+`permalink`
+:   Eine dauerhafte URL, die stets auf dieselbe Ressource zeigt.
+
 `postcondition`
 :   Eine Bedingung, die nach einer Operation garantiert gilt.
 
@@ -412,6 +565,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `PR`
 :   Pull Request — eine zur Review und zum Merge eingereichte Änderung.
+
+`pseudonymisation`
+:   Das Ersetzen identifizierender Felder durch Pseudonyme, sodass eine Re-Identifizierung Zusatzdaten braucht.
 
 `px`
 :   CSS-Pixel-Einheit.
@@ -434,8 +590,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `reflog`
 :   Gits Protokoll darüber, wohin Referenzen gezeigt haben (`git reflog`).
 
+`renderer`
+:   Eine Komponente, die ein Modell oder Markup in visuelle Ausgabe umwandelt.
+
 `reusable`
 :   In anderem Kontext wiederverwendbar.
+
+`ruleset`
+:   Eine benannte, gruppierte Sammlung von Regeln.
 
 `runbook`
 :   Eine dokumentierte Prozedur zum Betreiben oder Wiederherstellen eines Systems.
@@ -443,11 +605,26 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `runtime`
 :   Die Umgebung, in der ein Programm ausgeführt wird; Plural runtimes.
 
+`Sachtextformel`
+:   Eine deutsche Lesbarkeitsformel für Sachtexte (Wiener Sachtextformel).
+
 `sandboxing`
 :   Code so isolieren, dass er den Host nicht über eine erlaubte Grenze hinaus beeinflusst.
 
 `scannability`
 :   Wie leicht sich Text mit dem Auge überfliegen lässt.
+
+`schnell`
+:   Wie im schnellen Bildmodell FLUX.1 [schnell].
+
+`scriptable`
+:   Per Skript steuerbar statt nur interaktiv.
+
+`SDKs`
+:   Software Development Kits — Bibliotheken und Werkzeuge zum Entwickeln auf einer Plattform.
+
+`segmenter`
+:   Eine Komponente, die Text in Einheiten wie Sätze oder Wörter zerlegt.
 
 `SemVer`
 :   Semantic Versioning — das Schema `MAJOR.MINOR.PATCH`.
@@ -464,11 +641,20 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `snackbar`
 :   Eine kurze, nicht-blockierende Benachrichtigung an einem Bildschirmrand.
 
+`snapshot`
+:   Ein festgehaltener Referenzzustand, gegen den spätere Läufe verglichen werden, wie beim Snapshot-Testing.
+
+`Spatien`
+:   Typografische Bezeichnung für die schmalen Zwischenräume um bestimmte Zeichen.
+
 `sref`
 :   Midjourneys Parameter für Stilreferenzen (`--sref`).
 
 `SRE`
 :   Site Reliability Engineering bzw. ein Site Reliability Engineer.
+
+`subcommand`
+:   Ein verschachtelter Befehl unter einem CLI-Hauptbefehl, z. B. `git commit`.
 
 `Subresource`
 :   Eine Ressource, die eine Seite zusätzlich zu sich selbst lädt, wie bei Subresource Integrity.
@@ -476,14 +662,26 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `stylers`
 :   Komponenten oder Werkzeuge, die visuelle Gestaltung anwenden.
 
+`superset`
+:   Eine Menge, die eine andere vollständig enthält, z. B. TypeScript über JavaScript.
+
+`suppression`
+:   Eine Anweisung, die einen bestimmten Lint- oder Scanner-Befund unterdrückt.
+
 `symbolication`
 :   Das Rückführen von Speicheradressen eines Absturzes auf Quellcode-Symbole.
 
 `teardown`
 :   Aufräumarbeiten nach einem Test oder Prozess.
 
+`telemedia`
+:   Online-Dienste im Sinne des deutschen Telemedienrechts zu Datenschutz und Cookies.
+
 `thresholding`
 :   Das Anwenden eines Schwellenwerts zum Klassifizieren oder Filtern.
+
+`tokenizer`
+:   Eine Komponente, die Text in Tokens zerlegt; der Vorgang ist die Tokenisierung.
 
 `tooltip`
 :   Ein kleiner Hinweis, der bei Hover oder Fokus erscheint.
@@ -491,8 +689,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `typecheck`
 :   Ein Programm gegen seine Typregeln prüfen.
 
+`Unlicense`
+:   Eine Software-Lizenz, die einer Public-Domain-Freigabe gleichkommt.
+
 `unparseable`
 :   Nicht parsebar.
+
+`untyped`
+:   Ohne statische Typinformation.
 
 `validator`
 :   Eine Komponente, die Eingaben gegen Regeln prüft.
@@ -505,6 +709,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `worktree`
 :   Ein verknüpftes Arbeitsverzeichnis eines Git-Repositories.
+
+`XPath`
+:   Eine Abfragesprache zum Auswählen von Knoten in einem XML- oder HTML-Dokument.
 
 `YAML`
 :   YAML Ain't Markup Language — ein menschenlesbares Datenserialisierungsformat.
@@ -571,11 +778,17 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `mandatoriness`
 :   Das Maß, in dem etwas verpflichtend ist.
 
+`monolingually`
+:   Nur in einer einzigen Sprache.
+
 `namespace`
 :   Ein benannter Geltungsbereich, der Bezeichner eindeutig macht; namespaced.
 
 `onboarding`
 :   Einen neuen Nutzer, Beitragenden oder ein Repo auf den aktuellen Stand bringen.
+
+`operationalisation`
+:   Das Überführen eines Konzepts in eine konkrete, ausführbare Prozedur.
 
 `operationalize`
 :   Ein Konzept in eine konkrete, ausführbare Prozedur überführen.
@@ -622,8 +835,14 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `scaffold`
 :   Ein Startgerüst aus Dateien erzeugen; scaffolding.
 
+`scaffolder`
+:   Ein Werkzeug, das ein Startgerüst aus Dateien erzeugt.
+
 `slugification`
 :   Das Umwandeln einer Zeichenkette in einen URL-tauglichen Slug.
+
+`slugify`
+:   Eine Zeichenkette in einen URL-tauglichen Slug umwandeln.
 
 `subagent`
 :   Ein Agent, der von einem anderen Agenten beauftragt wird.
@@ -643,6 +862,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 `subtask`
 :   Eine Aufgabe, die Teil einer größeren ist.
 
+`swappable`
+:   Gegen eine gleichwertige Komponente austauschbar.
+
 `toolchain`
 :   Die Gesamtheit der Werkzeuge zum Bauen und Ausliefern von Software.
 
@@ -651,6 +873,9 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 `triggerer`
 :   Der Akteur oder das Ereignis, das etwas auslöst.
+
+`unautomated`
+:   Noch nicht automatisiert; weiterhin von Hand erledigt.
 
 `underperforming`
 :   Unter der Erwartung abschneidend.
@@ -681,7 +906,7 @@ Jeder Begriff, den die Vokabulare dieses Pakets akzeptieren, erklärt. Die Eintr
 
 ### Eigennamen — Quellen aus Schreiben, Lesbarkeit und Barrierefreiheit
 
-Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in den Specs des Projekts zu Lesbarkeit, redaktionellem Stil und Barrierefreiheit auftauchen; die drei Begriffe zur Farbwahrnehmung stammen aus dem Bereich Barrierefreiheit.
+Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in den Specs des Projekts zu Lesbarkeit, redaktionellem Stil, Testing, Software-Handwerk und Datenschutz auftauchen; die drei Begriffe zur Farbwahrnehmung stammen aus dem Bereich Barrierefreiheit.
 
 `Bamberger`
 :   Mitbegründer der deutschsprachigen Lesbarkeitsforschung, gemeinsam mit Vanecek.
@@ -692,14 +917,26 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 `Chissom`
 :   Mitautor der Flesch-Kincaid-Klassenstufen-Studie.
 
+`Cohn`
+:   Mike Cohn, Autor zu agiler Schätzung und der Testpyramide.
+
 `Desrosiers`
 :   Nachname, der als Quelle in den Specs zu Lesbarkeit/Schreiben zitiert wird.
+
+`Dodds`
+:   Kent C. Dodds, Autor zu Testing und React (die Testing-Trophy).
+
+`Duden`
+:   Das maßgebliche deutsche Rechtschreibwörterbuch.
 
 `Fishburne`
 :   Mitautor der Flesch-Kincaid-Klassenstufen-Studie.
 
 `Flesch`
 :   Rudolf Flesch, Urheber des Flesch-Reading-Ease-Werts.
+
+`Habib`
+:   Nachname, der als Quelle in den Specs des Projekts zitiert wird.
 
 `Kalzumeus`
 :   Blog und Handle des Software-Autors Patrick McKenzie.
@@ -716,6 +953,24 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 `Matuschak`
 :   Andy Matuschak, bekannt für Arbeiten zu Notizen und Wissenswerkzeugen.
 
+`Meszaros`
+:   Gerard Meszaros, Autor eines grundlegenden Buchs über Unit-Test-Muster und Test-Doubles.
+
+`Ottinger`
+:   Tim Ottinger, Autor im Bereich Software-Handwerk.
+
+`Pradel`
+:   Nachname, der als Quelle in den Test-Specs des Projekts zitiert wird.
+
+`Sadowski`
+:   Nachname, der als Quelle in den Software-Engineering-Specs des Projekts zitiert wird.
+
+`Schrems`
+:   Max Schrems, der Datenschutzaktivist hinter den Schrems-Urteilen zum Datentransfer.
+
+`Schuchert`
+:   Brett Schuchert, Autor im Bereich Software-Handwerk.
+
 `Stockton`
 :   Nachname, der als Quelle in den Specs zu Schreiben/Lesbarkeit zitiert wird.
 
@@ -724,6 +979,9 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 
 `Vanecek`
 :   Mitbegründer der deutschsprachigen Lesbarkeitsforschung, gemeinsam mit Bamberger.
+
+`Vocke`
+:   Ham Vocke, Autor eines viel zitierten Artikels zur Testpyramide.
 
 `Zinsser`
 :   William Zinsser, Autor von „On Writing Well“.
@@ -790,6 +1048,9 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 `stderr`
 :   Standard-Fehlerausgabe (Standard error).
 
+`stdlib`
+:   Kurzform für die Standardbibliothek einer Sprache.
+
 `stdout`
 :   Standardausgabe (Standard output).
 
@@ -810,7 +1071,7 @@ Diese Nachnamen werden akzeptiert, weil sie als zitierte Autoren oder Quellen in
 
 ### Beugungs- und Possessivformen
 
-Einige Einträge existieren nur, damit die Rechtschreibprüfung eine Beugungs- oder Possessivform akzeptiert, und tragen keine Bedeutung über ihr Grundwort hinaus: `commit's`, `criteria's`, `else's`, `maintainer's`, `README's` und `navigations`.
+Einige Einträge existieren nur, damit die Rechtschreibprüfung eine Beugungs- oder Possessivform akzeptiert, und tragen keine Bedeutung über ihr Grundwort hinaus: `commit's`, `criteria's`, `else's`, `Gemma's`, `maintainer's`, `navigations`, `README's` und `rebased`.
 
 ## Vokabular `esphome`
 

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -339,7 +339,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Command-Line Interface.
 
 `clickability`
-:   How readily an element invites and registers a click.
+:   How easily a user can tell an element is clickable and hit it.
 
 `closeable`
 :   Able to be closed — said of a resource that must be released.
@@ -372,7 +372,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   To delay handling of rapid repeated events until they settle.
 
 `decompounding`
-:   Splitting a compound word into its parts, common in German text processing; a decompounder does this.
+:   Splitting a compound word into its parts, common in German text processing; the component that does it is a decompounder.
 
 `dedup`
 :   Short for deduplicate.
@@ -675,7 +675,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 :   Cleanup run after a test or process.
 
 `telemedia`
-:   German online-services governed by tele-media law on privacy and cookies.
+:   Online services regulated under German tele-media law on privacy and cookies.
 
 `thresholding`
 :   Applying a cut-off value to classify or filter.

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -30,8 +30,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Claude`
 :   Anthropic's family of large language models.
 
+`Cloudflare`
+:   Edge-network, CDN, and security provider.
+
 `Contentful`
 :   API-first headless content-management system.
+
+`ControlNet`
+:   A neural add-on that conditions image generation on an input like edges or pose.
 
 `cookiecutter`
 :   Project-scaffolding tool that renders a template from a set of answers.
@@ -44,6 +50,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `Deque`
 :   Accessibility-tooling company behind the axe testing engine.
+
+`Docusaurus`
+:   A React-based static-site generator for documentation.
 
 `DOMPurify`
 :   Client-side HTML sanitiser that strips XSS-prone markup.
@@ -60,6 +69,15 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Figma`
 :   Browser-based collaborative interface-design tool.
 
+`FLUX`
+:   A family of text-to-image generation models by Black Forest Labs.
+
+`Gemini`
+:   Google's family of multimodal large language models.
+
+`Gemma`
+:   Google's family of open-weight language models.
+
 `gh-plumbing`
 :   nolte's shared repository of reusable GitHub Actions workflows and Probot configurations.
 
@@ -72,6 +90,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Graphviz`
 :   Graph-visualisation toolkit driven by the DOT language.
 
+`Imagen`
+:   Google's text-to-image generation model.
+
 `Inkbot`
 :   Third-party design studio referenced in the project's specs.
 
@@ -80,6 +101,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `JUnit`
 :   Java unit-testing framework whose XML report format is a CI standard.
+
+`kamerplanter`
+:   A nolte project (a houseplant-care assistant).
 
 `Mailchimp`
 :   Email-marketing and newsletter platform.
@@ -93,11 +117,20 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `MkDocs`
 :   Static-site generator for project documentation, used here with the Material theme.
 
+`Mockito`
+:   A mocking framework for Java unit tests.
+
 `MUI`
 :   Material UI, a React component library implementing Material Design.
 
+`mutmut`
+:   A mutation-testing tool for Python.
+
 `mypy`
 :   Static type checker for Python.
+
+`Netlify`
+:   A hosting and deployment platform for web frontends.
 
 `nginx`
 :   High-performance web server and reverse proxy.
@@ -114,11 +147,20 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Numonic`
 :   Third-party brand referenced in the project's specs.
 
+`pitest`
+:   A mutation-testing framework for Java (PIT).
+
+`Pollinations`
+:   An open generative-AI media API.
+
 `Probot`
 :   Framework for building GitHub Apps; backs the shared settings and labelling bots.
 
 `Pyright`
 :   Microsoft's static type checker for Python.
+
+`pytest`
+:   The de-facto testing framework for Python.
 
 `Recharts`
 :   React charting library built on D3.
@@ -126,14 +168,29 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Renovate`
 :   Automated dependency-update tool, configured here via a shared preset.
 
+`SDXL`
+:   Stable Diffusion XL, a text-to-image generation model.
+
 `Shiki`
 :   Syntax highlighter that uses TextMate grammars and editor themes.
+
+`Sinon`
+:   A JavaScript library for test spies, stubs, and mocks.
 
 `Skywork`
 :   Third-party AI service referenced in the project's specs.
 
+`Spotify`
+:   The music-streaming service.
+
+`Stryker`
+:   A mutation-testing framework for JavaScript, C#, and Scala.
+
 `Supabase`
 :   Open-source backend platform built on PostgreSQL.
+
+`Syft`
+:   A tool that generates a software bill of materials (SBOM) from images and filesystems.
 
 `Tailwind`
 :   Utility-first CSS framework.
@@ -144,8 +201,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Tauri`
 :   Framework for building desktop apps with a web frontend and a Rust core.
 
+`Testcontainers`
+:   A library that runs throwaway Docker containers for integration tests.
+
 `textstat`
 :   Python library that computes readability metrics.
+
+`Thoughtworks`
+:   A software consultancy, known for the Technology Radar.
 
 `Trivy`
 :   Open-source security and vulnerability scanner.
@@ -171,8 +234,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `Vue`
 :   Progressive JavaScript framework for building user interfaces.
 
+`Wayback`
+:   As in the Wayback Machine, the Internet Archive's web-snapshot service.
+
 `Webheads`
 :   Third-party brand referenced in the project's specs.
+
+`Zlib`
+:   A lossless data-compression library; also the name of its permissive licence.
 
 `Zod`
 :   TypeScript-first schema declaration and validation library.
@@ -202,6 +271,12 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `allowlist`
 :   An explicit set of permitted entities; the inclusive counterpart to a denylist.
+
+`alphanumerics`
+:   Characters that are letters or digits.
+
+`anonymisation`
+:   Irreversibly stripping personal data so individuals can no longer be identified.
 
 `API`
 :   Application Programming Interface — a defined contract between software components.
@@ -236,6 +311,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `backlink`
 :   A link pointing back to a page that references it.
 
+`backoff`
+:   Progressively increasing the delay between retries.
+
 `bluetooth`
 :   Short-range wireless connectivity standard.
 
@@ -248,17 +326,32 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `callout`
 :   A visually set-off note or admonition in documentation.
 
+`CDN`
+:   Content Delivery Network — geographically distributed servers that cache and serve content close to users.
+
+`charset`
+:   Character set — the encoding that maps bytes to characters.
+
 `CI`
 :   Continuous Integration — automatically building and testing every change.
 
 `CLI`
 :   Command-Line Interface.
 
+`clickability`
+:   How readily an element invites and registers a click.
+
 `closeable`
 :   Able to be closed — said of a resource that must be released.
 
+`colocated`
+:   Placed in the same location, e.g. a test file beside the code it tests.
+
 `conformant`
 :   Adhering to a specification or standard.
+
+`copyrightability`
+:   Whether a work is eligible for copyright protection.
 
 `cron`
 :   Time-based job scheduler; also the syntax for its schedules.
@@ -272,8 +365,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `CVE`
 :   Common Vulnerabilities and Exposures — a public identifier for a security flaw.
 
+`datastore`
+:   A system that persists data (database, key-value store, object store).
+
 `debounce`
 :   To delay handling of rapid repeated events until they settle.
+
+`decompounding`
+:   Splitting a compound word into its parts, common in German text processing; a decompounder does this.
 
 `dedup`
 :   Short for deduplicate.
@@ -283,6 +382,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `denylist`
 :   An explicit set of blocked entities; the counterpart to an allowlist.
+
+`deserialise`
+:   To reconstruct an in-memory object from a serialised form; the act is deserialisation.
 
 `devcontainer`
 :   A container-defined, reproducible development environment.
@@ -302,8 +404,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `docstring`
 :   An inline documentation string embedded in source code.
 
+`DTOs`
+:   Data Transfer Objects — plain structures that carry data across boundaries.
+
 `enum`
 :   Enumeration — a type with a fixed set of named values.
+
+`ePrivacy`
+:   The EU ePrivacy Directive governing electronic communications and cookies.
 
 `favicon`
 :   The small icon a browser shows for a site.
@@ -320,6 +428,12 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `frontmatter`
 :   The metadata block, often YAML, at the top of a Markdown file.
 
+`Gedankenstrich`
+:   German for the em or en dash used as a parenthetical or range mark.
+
+`generativelanguage`
+:   The host segment of Google's Generative Language API (`generativelanguage.googleapis.com`).
+
 `geoblocking`
 :   Restricting access to content by geographic region.
 
@@ -329,8 +443,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `GHSA`
 :   GitHub Security Advisory identifier.
 
+`Goodhart`
+:   As in Goodhart's law: once a measure becomes a target, it stops being a good measure.
+
 `Guillemets`
 :   Angle-shaped quotation marks (« »).
+
+`hardcoded`
+:   Written as a fixed literal in source rather than configured.
 
 `HMAC`
 :   Hash-based Message Authentication Code — a keyed integrity and authenticity check.
@@ -356,14 +476,32 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `inspectable`
 :   Able to be examined at runtime or via tooling.
 
+`Komposita`
+:   German for compound words, e.g. in readability analysis.
+
+`latents`
+:   The compressed latent-space representations a generative model works in.
+
 `lede`
 :   The opening of an article that states its core point; plural ledes.
+
+`lektorat`
+:   German for a copy-edit or editorial review pass over prose.
+
+`liveness`
+:   Whether a running process is healthy enough to keep serving, as in a liveness probe.
+
+`LIX`
+:   A readability index based on word and sentence length.
 
 `lockfile`
 :   A file pinning exact resolved dependency versions.
 
 `lookup`
 :   A retrieval of a value by key.
+
+`LoRA`
+:   Low-Rank Adaptation — an efficient fine-tuning method for large models.
 
 `lossy`
 :   Discarding some information, as in lossy compression.
@@ -380,20 +518,32 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `mitigation`
 :   A measure that reduces a risk's likelihood or impact.
 
+`mockist`
+:   A testing style that favours mocks to isolate the unit under test, as opposed to classicist.
+
 `monorepo`
 :   A single repository holding many projects.
 
 `MR`
 :   Merge Request — GitLab's term for a pull request.
 
+`multimodal`
+:   Handling more than one input or output modality, such as text and images.
+
 `MUSTs` / `SHOULDs`
 :   Pluralised RFC 2119 requirement keywords.
+
+`nano`
+:   The smallest variant of a model family, e.g. Gemini Nano.
 
 `Newswire`
 :   A service that distributes news copy to outlets.
 
 `NFR`
 :   Non-Functional Requirement — a quality constraint such as performance or security.
+
+`nominalisation`
+:   Turning a verb or adjective into a noun, often a readability smell.
 
 `OAuth`
 :   Open standard for delegated authorization.
@@ -404,6 +554,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `parseable`
 :   Able to be parsed.
 
+`permalink`
+:   A permanent URL that keeps pointing at the same resource.
+
 `postcondition`
 :   A condition guaranteed to hold after an operation.
 
@@ -412,6 +565,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `PR`
 :   Pull Request — a proposed change submitted for review and merge.
+
+`pseudonymisation`
+:   Replacing identifying fields with pseudonyms so re-identification needs extra data.
 
 `px`
 :   CSS pixel unit.
@@ -434,8 +590,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `reflog`
 :   A log of where Git references have pointed (`git reflog`).
 
+`renderer`
+:   A component that turns a model or markup into visual output.
+
 `reusable`
 :   Able to be used again in another context.
+
+`ruleset`
+:   A named, grouped collection of rules.
 
 `runbook`
 :   A documented procedure for operating or recovering a system.
@@ -443,11 +605,26 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `runtime`
 :   The environment in which a program executes; plural runtimes.
 
+`Sachtextformel`
+:   A German readability formula for non-fiction text.
+
 `sandboxing`
 :   Isolating code so it cannot affect the host beyond a permitted boundary.
 
 `scannability`
 :   How easily text can be skimmed by eye.
+
+`schnell`
+:   German for fast; as in the FLUX.1 [schnell] image model.
+
+`scriptable`
+:   Drivable through a script rather than only interactively.
+
+`SDKs`
+:   Software Development Kits — libraries and tools for building on a platform.
+
+`segmenter`
+:   A component that splits text into units such as sentences or words.
 
 `SemVer`
 :   Semantic Versioning — the `MAJOR.MINOR.PATCH` version scheme.
@@ -464,11 +641,20 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `snackbar`
 :   A brief, non-blocking notification shown at a screen edge.
 
+`snapshot`
+:   A captured reference state compared against on later runs, as in snapshot testing.
+
+`Spatien`
+:   German typographic term for the thin spaces set around certain marks.
+
 `sref`
 :   Midjourney's style-reference parameter (`--sref`).
 
 `SRE`
 :   Site Reliability Engineering, or a Site Reliability Engineer.
+
+`subcommand`
+:   A nested command under a top-level CLI command, e.g. `git commit`.
 
 `Subresource`
 :   A resource a page loads in addition to itself, as in Subresource Integrity.
@@ -476,14 +662,26 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `stylers`
 :   Components or tools that apply visual styling.
 
+`superset`
+:   A set that fully contains another, e.g. TypeScript over JavaScript.
+
+`suppression`
+:   A directive that silences a specific lint or scanner finding.
+
 `symbolication`
 :   Mapping memory addresses in a crash back to source symbols.
 
 `teardown`
 :   Cleanup run after a test or process.
 
+`telemedia`
+:   German online-services governed by tele-media law on privacy and cookies.
+
 `thresholding`
 :   Applying a cut-off value to classify or filter.
+
+`tokenizer`
+:   A component that splits text into tokens; the act is tokenization.
 
 `tooltip`
 :   A small hint shown on hover or focus.
@@ -491,8 +689,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `typecheck`
 :   To verify a program against its type rules.
 
+`Unlicense`
+:   A public-domain-equivalent software licence.
+
 `unparseable`
 :   Not able to be parsed.
+
+`untyped`
+:   Without static type information.
 
 `validator`
 :   A component that checks input against rules.
@@ -505,6 +709,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `worktree`
 :   A linked working directory of a Git repository.
+
+`XPath`
+:   A query language for selecting nodes in an XML or HTML document.
 
 `YAML`
 :   YAML Ain't Markup Language — a human-readable data-serialisation format.
@@ -571,11 +778,17 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `mandatoriness`
 :   The degree to which something is mandatory.
 
+`monolingually`
+:   In a single language only.
+
 `namespace`
 :   A named scope that keeps identifiers distinct; namespaced.
 
 `onboarding`
 :   Bringing a new user, contributor, or repository up to speed.
+
+`operationalisation`
+:   Turning a concept into a concrete, runnable procedure.
 
 `operationalize`
 :   To turn a concept into a concrete, runnable procedure.
@@ -622,8 +835,14 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `scaffold`
 :   To generate a starting skeleton of files; scaffolding.
 
+`scaffolder`
+:   A tool that generates a starting skeleton of files.
+
 `slugification`
 :   Converting a string into a URL-safe slug.
+
+`slugify`
+:   To convert a string into a URL-safe slug.
 
 `subagent`
 :   An agent dispatched by another agent.
@@ -643,6 +862,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 `subtask`
 :   A task that is part of a larger one.
 
+`swappable`
+:   Able to be exchanged for an equivalent component.
+
 `toolchain`
 :   The set of tools used to build and ship software.
 
@@ -651,6 +873,9 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 `triggerer`
 :   The actor or event that triggers something.
+
+`unautomated`
+:   Not yet automated; still done by hand.
 
 `underperforming`
 :   Performing below expectation.
@@ -681,7 +906,7 @@ Every term this package's vocabularies accept, defined. Entries are grouped into
 
 ### Proper names — writing, readability, and accessibility sources
 
-These surnames are accepted because they appear as cited authors or sources in the project's readability, editorial-style, and accessibility specs; the three colour-vision terms come from the accessibility domain.
+These surnames are accepted because they appear as cited authors or sources in the project's specs on readability, editorial style, testing, software craft, and data protection; the three colour-vision terms come from the accessibility domain.
 
 `Bamberger`
 :   Co-originator, with Vanecek, of German-language readability research.
@@ -692,14 +917,26 @@ These surnames are accepted because they appear as cited authors or sources in t
 `Chissom`
 :   Co-author of the Flesch–Kincaid grade-level study.
 
+`Cohn`
+:   Mike Cohn, an author on agile estimation and the test pyramid.
+
 `Desrosiers`
 :   Surname cited as a source in the readability/writing specs.
+
+`Dodds`
+:   Kent C. Dodds, a testing and React author (the testing trophy).
+
+`Duden`
+:   The authoritative German-language spelling dictionary.
 
 `Fishburne`
 :   Co-author of the Flesch–Kincaid grade-level study.
 
 `Flesch`
 :   Rudolf Flesch, originator of the Flesch Reading Ease score.
+
+`Habib`
+:   Surname cited as a source in the project's specs.
 
 `Kalzumeus`
 :   The blog and handle of software writer Patrick McKenzie.
@@ -716,6 +953,24 @@ These surnames are accepted because they appear as cited authors or sources in t
 `Matuschak`
 :   Andy Matuschak, known for work on notes and knowledge tools.
 
+`Meszaros`
+:   Gerard Meszaros, author of a foundational book on unit-test patterns and test doubles.
+
+`Ottinger`
+:   Tim Ottinger, a software-craft author.
+
+`Pradel`
+:   Surname cited as a source in the project's testing specs.
+
+`Sadowski`
+:   Surname cited as a source in the project's software-engineering specs.
+
+`Schrems`
+:   Max Schrems, the privacy advocate behind the Schrems data-transfer rulings.
+
+`Schuchert`
+:   Brett Schuchert, a software-craft author.
+
 `Stockton`
 :   Surname cited as a source in the writing/readability specs.
 
@@ -724,6 +979,9 @@ These surnames are accepted because they appear as cited authors or sources in t
 
 `Vanecek`
 :   Co-originator, with Bamberger, of German-language readability research.
+
+`Vocke`
+:   Ham Vocke, author of a widely cited article on the test pyramid.
 
 `Zinsser`
 :   William Zinsser, author of "On Writing Well".
@@ -790,6 +1048,9 @@ These surnames are accepted because they appear as cited authors or sources in t
 `stderr`
 :   Standard error stream.
 
+`stdlib`
+:   Short for a language's standard library.
+
 `stdout`
 :   Standard output stream.
 
@@ -810,7 +1071,7 @@ These surnames are accepted because they appear as cited authors or sources in t
 
 ### Inflected and possessive forms
 
-A few entries exist only so the spell-checker accepts an inflected or possessive form and carry no meaning beyond their base word: `commit's`, `criteria's`, `else's`, `maintainer's`, `README's`, and `navigations`.
+A few entries exist only so the spell-checker accepts an inflected or possessive form and carry no meaning beyond their base word: `commit's`, `criteria's`, `else's`, `Gemma's`, `maintainer's`, `navigations`, `README's`, and `rebased`.
 
 ## `esphome` vocabulary
 


### PR DESCRIPTION
## Summary

Bring the bilingual glossary back to full coverage after PR #24 added 100 entries to the `technical` vocabulary, then run an editorial pass over the new definitions. Content-only — the vocabulary itself is unchanged.

## Changes

- Add ~87 new definitions (EN + DE) for the entries imported in #24, classified into the existing families: tools/brands (Cloudflare, Docusaurus, pytest, Mockito, Stryker, Syft, Testcontainers, the AI image/model names, …), engineering/CI/security/docs terms (CDN, DTOs, ePrivacy, pseudonymisation, tokenizer, snapshot, XPath, …), naming/lifecycle words, proper names (testing, software-craft, and data-protection authorities), and shorthands.
- Broaden the proper-names family intro to cover testing, software craft, and data protection alongside readability and accessibility.
- Fold the trivial forms `Gemma's` and `rebased` into the inflected-forms line.
- Editorial pass: reword `clickability` in both languages, smooth `telemedia` (EN) and the `decompounding` clause, for clarity.

## Linked issues

None

## Testing

- `mkdocs build --strict` — clean; both language trees build, 371 definition terms each.
- Coverage check — every `technical` and `esphome` accept.txt entry is present (0 gaps).
- LanguageTool on the new German definitions — no mixed quotes, no real grammar findings (one false positive on "Internet Archive").
- `vale .` — 0 errors across 24 files; `task --yes lint` / pre-commit pass.

## Risk / rollout notes

Docs-only; the release zip (`nolte-styles.zip`) and the vocabularies are unaffected. Ships on the next `release-cd-deliver-docs.yml` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)